### PR TITLE
I've streamlined the README.md regarding Jina AI integration.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,10 @@ AUTHOR="your_name"
 # FireCrawl配置 https://www.firecrawl.dev/
 FIRE_CRAWL_API_KEY="your_api_key"
 
+# Jina AI API Key - Get yours from https://jina.ai/?sui=apikey
+# Used for Jina Reader, DeepSearch, Embedding, and Reranker providers
+JINA_API_KEY="your_jina_api_key"
+
 # Twitter API配置 https://twitterapi.io/
 X_API_BEARER_TOKEN="your_api_key"
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ cd ai-trend-publish
 ```bash
 cp .env.example .env
 # 编辑 .env 文件配置必要的环境变量
+# Key environment variables include API keys for various AI services.
+# For Jina AI functionalities (scraping, search, embeddings, reranking),
+# ensure JINA_API_KEY is set. See the .env.example file and the
+# Jina Integration Guide for more details.
 ```
 
 ### 4. 开发和运行
@@ -79,12 +83,14 @@ deno task build:all
   - Twitter/X 内容抓取
   - 网站内容抓取 (基于 FireCrawl)
   - 支持自定义数据源配置
+  - Advanced scraping and search via Jina AI
 
 - 🧠 AI 智能处理
 
   - 使用 DeepseekAI Together 千问 万象 讯飞 进行内容总结
   - 关键信息提取
   - 智能标题生成
+  - Text embeddings and reranking via Jina AI
 
 - 📢 自动发布
 
@@ -136,10 +142,11 @@ TrendPublish 提供了多种精美的文章模板。查看
 ## 🛠 技术栈
 
 - **运行环境**: Deno + TypeScript
-- **AI 服务**: DeepseekAI Together 千问 万象 讯飞
+- **AI 服务**: DeepseekAI Together 千问 万象 讯飞 Jina AI (see [Integration Guide](docs/jina_integration_guide.md))
 - **数据源**:
   - Twitter/X API
   - FireCrawl
+  - Jina AI (for scraping and search, see [Integration Guide](docs/jina_integration_guide.md))
 - **模板引擎**: EJS
 - **开发工具**:
   - Deno
@@ -165,11 +172,17 @@ git clone https://github.com/OpenAISpace/ai-trend-publish
 ```bash
 cp .env.example .env
 # 编辑 .env 文件配置必要的环境变量
+# Key environment variables include API keys for various AI services.
+# For Jina AI functionalities (scraping, search, embeddings, reranking),
+# ensure JINA_API_KEY is set. See the .env.example file and the
+# Jina Integration Guide (docs/jina_integration_guide.md) for more details.
 ```
 
 ## ⚙️ 环境变量配置
 
 在 `.env` 文件中配置必要的环境变量：
+
+(Refer to `.env.example` for a comprehensive list of environment variables. For details on Jina AI specific setup, see the [Jina Integration Guide](docs/jina_integration_guide.md)).
 
 ## ⚠️ 配置IP白名单
 

--- a/docs/jina_integration_guide.md
+++ b/docs/jina_integration_guide.md
@@ -1,0 +1,64 @@
+# Jina AI Integration Guide
+
+This document provides a brief overview of how Jina AI is integrated into this project and how to use the Jina-powered components.
+
+## Overview
+
+Jina AI is utilized to provide advanced functionalities such as:
+
+*   **Web Scraping**: Using the Jina Reader API to fetch and parse content from web pages.
+*   **Deep Search**: Leveraging the Jina DeepSearch API for comprehensive, intelligent search capabilities.
+*   **Text Embeddings**: Generating vector embeddings for text using the Jina Embeddings API.
+*   **Search Result Reranking**: Improving the relevance of search results using the Jina Reranker API.
+
+## Prerequisites
+
+**JINA_API_KEY**: All Jina AI components require a JINA_API_KEY to be set as an environment variable.
+
+```bash
+export JINA_API_KEY="your_actual_api_key_here"
+```
+
+You can obtain a free API key from the [Jina AI Website](https://jina.ai/?sui=apikey). Please refer to the main `README.md` or `.env.example` for more details on environment variable setup.
+
+## Components
+
+### 1. Web Scraper (JinaReader)
+
+*   **Class**: `JinaScraper`
+*   **Location**: `src/modules/scrapers/jina/jina.scraper.ts`
+*   **API Used**: Jina Reader API (`r.jina.ai`)
+*   **Description**: Fetches content from a given URL.
+*   **Usage**: Can be instantiated via `ScraperFactory.createScraper(ScraperType.JINA_READER)` or directly. Implements the `ContentScraper` interface.
+
+### 2. Deep Search Scraper (JinaDeepSearch)
+
+*   **Class**: `JinaDeepSearchScraper`
+*   **Location**: `src/modules/scrapers/jina/jina.deepsearch.scraper.ts`
+*   **API Used**: Jina DeepSearch API (`deepsearch.jina.ai`)
+*   **Description**: Performs a deep search based on a query string and returns a synthesized answer along with source URLs.
+*   **Usage**: Can be instantiated via `ScraperFactory.createScraper(ScraperType.JINA_DEEPSEARCH)` or directly. Implements the `ContentScraper` interface.
+
+### 3. Embedding Provider (JinaEmbeddings)
+
+*   **Class**: `JinaEmbeddingProvider`
+*   **Location**: `src/providers/embedding/jina/jina.embedding.ts`
+*   **API Used**: Jina Embeddings API (`api.jina.ai/v1/embeddings`)
+*   **Description**: Generates numerical vector representations (embeddings) for input text.
+*   **Usage**: Can be instantiated via `EmbeddingFactory.createProvider(EmbeddingProviderType.JINA, { model: "jina-embeddings-v2-base-en" })` or directly. Implements the `EmbeddingProvider` interface. Different Jina embedding models can be specified.
+
+### 4. Reranker Provider (JinaReranker)
+
+*   **Class**: `JinaRerankerProvider`
+*   **Location**: `src/providers/reranker/jina/jina.reranker.ts`
+*   **API Used**: Jina Reranker API (`api.jina.ai/v1/rerank`)
+*   **Description**: Reranks a list of documents based on their relevance to a given query.
+*   **Usage**: Can be instantiated directly. Implements the `RerankerProvider` interface. Different Jina reranker models can be specified.
+
+## Configuration
+
+Most Jina components are configured at instantiation, often by specifying the Jina model to use (e.g., for embeddings or reranking). Refer to the respective class constructors and methods for specific options. The API key is globally configured via the environment variable.
+
+## Further Information
+
+For more detailed information on Jina AI APIs and their capabilities, please refer to the [official Jina AI documentation](https://docs.jina.ai/).

--- a/src/modules/scrapers/jina/jina.deepsearch.scraper.ts
+++ b/src/modules/scrapers/jina/jina.deepsearch.scraper.ts
@@ -1,0 +1,259 @@
+// Get your Jina AI API key for free: https://jina.ai/?sui=apikey
+
+import {
+  ContentScraper,
+  ScrapedContent,
+  ScraperOptions,
+  // Media, // Media is unlikely to be directly from deepsearch text results
+} from "@src/modules/interfaces/scraper.interface.ts";
+import { z } from "npm:zod@3.23.8";
+
+// Zod Schema for Jina DeepSearch API Request (minimal)
+const DeepSearchRequestSchema = z.object({
+  model: z.string().default("jina-deepsearch-v1"),
+  messages: z.array(
+    z.object({
+      role: z.enum(["user", "assistant", "system"]),
+      content: z.string(),
+    }),
+  ),
+  stream: z.boolean().default(false),
+  // Potentially add other parameters like max_returned_urls if supported and relevant
+});
+
+// Zod Schema for Jina DeepSearch API Response
+const DeepSearchResponseSchema = z.object({
+  id: z.string().optional(), // Sometimes not present or not strictly needed by us
+  object: z.string().optional(), // e.g., "chat.completion"
+  created: z.number().optional(),
+  model: z.string(),
+  choices: z.array(
+    z.object({
+      index: z.number(),
+      message: z.object({
+        role: z.string(), // "assistant"
+        content: z.string(),
+      }),
+      finish_reason: z.string().optional(), // e.g., "stop"
+    }),
+  ),
+  usage: z
+    .object({
+      prompt_tokens: z.number().optional(),
+      completion_tokens: z.number().optional(),
+      total_tokens: z.number(),
+    })
+    .optional(),
+  // error: z.object({ message: z.string(), type: z.string(), code: z.string().nullable() }).optional(),
+});
+
+// Helper function to parse sources from content
+// This is a simple parser, might need to be more robust
+function parseSourcesFromContent(content: string): { mainContent: string; sources: { url: string, title?: string }[] } {
+  const sources: { url: string, title?: string }[] = [];
+  let mainContent = content;
+
+  const sourcesHeaderRegex = /\n\s*(sources|references|citations|links):\s*\n/i;
+  const match = sourcesHeaderRegex.exec(content);
+
+  if (match) {
+    mainContent = content.substring(0, match.index);
+    const sourcesText = content.substring(match.index + match[0].length);
+    
+    // Regex for markdown links: [title](url) or just URLs
+    // This regex looks for patterns like [1] https://example.com or [Source 1] https://example.com/path
+    // or simple URLs.
+    const sourceLineRegex = /(?:\[(?:[^\]]+?|(?:\d+))\]\s*)?(https?:\/\/[^\s\(\)]+)/g;
+    let sourceMatch;
+    while ((sourceMatch = sourceLineRegex.exec(sourcesText)) !== null) {
+      sources.push({ url: sourceMatch[1] });
+    }
+  }
+  // If no explicit "Sources:" section, try to find URLs anywhere in the text
+  // This could be noisy, so it's disabled by default. Add if necessary.
+  /*
+  else {
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    let urlMatch;
+    while ((urlMatch = urlRegex.exec(content)) !== null) {
+      // Avoid adding already captured URLs or parts of markdown if complex markdown is present
+      if (!sources.some(s => s.url === urlMatch[0])) {
+         // sources.push({ url: urlMatch[0], title: "Referenced URL" }); 
+      }
+    }
+  }
+  */
+
+  return { mainContent: mainContent.trim(), sources };
+}
+
+
+export class JinaDeepSearchScraper implements ContentScraper {
+  private apiKey: string;
+  private deepSearchApiUrl = "https://deepsearch.jina.ai/v1/chat/completions";
+
+  constructor() {
+    const apiKey = Deno.env.get("JINA_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "JINA_API_KEY environment variable is not set. " +
+        "Get your Jina AI API key for free: https://jina.ai/?sui=apikey",
+      );
+    }
+    this.apiKey = apiKey;
+  }
+
+  async scrape(
+    sourceId: string, // This will be the search query
+    options?: ScraperOptions, // Options might be used for model selection, etc.
+  ): Promise<ScrapedContent[]> {
+    console.info(`[JinaDeepSearchScraper] Searching with query: ${sourceId} with options: ${JSON.stringify(options)}`);
+
+    const requestBody = DeepSearchRequestSchema.parse({
+      model: "jina-deepsearch-v1", // Or make configurable via options
+      messages: [{ role: "user", content: sourceId }],
+      stream: false,
+      // Example: if options.limit is used to control number of results,
+      // it might map to a Jina param like `max_returned_urls` if supported by the API.
+      // This API endpoint (chat/completions) might not directly support it.
+    });
+
+    try {
+      const response = await fetch(this.deepSearchApiUrl, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(
+          `[JinaDeepSearchScraper] API request failed with status ${response.status}: ${errorBody}`,
+        );
+        // Attempt to parse Jina specific error structure if available
+        try {
+            const errJson = JSON.parse(errorBody);
+            if (errJson && errJson.error && errJson.error.message) {
+                 throw new Error(`Jina DeepSearch API Error: ${errJson.error.message} (Status: ${response.status})`);
+            }
+        } catch (e) { /* ignore parsing error, throw original text */ }
+        throw new Error(
+          `Jina DeepSearch API request failed with status ${response.status}: ${errorBody}`,
+        );
+      }
+
+      const result = await response.json();
+      const parsedResult = DeepSearchResponseSchema.safeParse(result);
+
+      if (!parsedResult.success) {
+        console.error(
+          `[JinaDeepSearchScraper] Invalid API response structure: ${parsedResult.error.toString()}`,
+          result
+        );
+        throw new Error(
+          `Jina DeepSearch API returned an invalid response structure. ${parsedResult.error.toString()}`,
+        );
+      }
+      
+      const apiData = parsedResult.data;
+
+      if (!apiData.choices || apiData.choices.length === 0) {
+        console.warn("[JinaDeepSearchScraper] API returned no choices.", apiData);
+        return [];
+      }
+
+      const messageContent = apiData.choices[0].message.content;
+      const { mainContent, sources } = parseSourcesFromContent(messageContent);
+
+      // For DeepSearch, the primary result is the synthesized answer.
+      // The sources found can be listed in metadata or as part of the content.
+      // The `ContentScraper` interface is geared towards scraping a *single* primary content object per URL.
+      // Here, the "URL" is the query itself.
+      // If we want each source to be a `ScrapedContent`, we'd need to fetch and parse each source URL.
+      // That's beyond the scope of this scraper; this scraper is for the DeepSearch *result itself*.
+
+      const scrapedContent: ScrapedContent = {
+        id: `jina-deepsearch-${sourceId}-${new Date().getTime()}`, // Unique ID for the search result
+        title: `Search Results for: "${sourceId.substring(0, 50)}${sourceId.length > 50 ? '...' : ''}"`,
+        content: mainContent,
+        url: `jina-deepsearch://query?${encodeURIComponent(sourceId)}`, // A virtual URL representing the query
+        publishDate: new Date().toISOString(),
+        media: [], // DeepSearch is text-based
+        metadata: {
+          query: sourceId,
+          model: apiData.model,
+          usage: apiData.usage,
+          originalResponse: options?.filters?.includeOriginalResponse ? messageContent : undefined, // Optional: include full response
+          sources: sources.map(s => s.url), // Store extracted source URLs
+          // If we had titles for sources: sources: sources
+        },
+      };
+
+      return [scrapedContent];
+    } catch (error) {
+      console.error(`[JinaDeepSearchScraper] Error processing query "${sourceId}":`, error);
+      if (error instanceof Error) {
+        throw new Error(`Failed to process query "${sourceId}" using Jina DeepSearch: ${error.message}`);
+      }
+      throw new Error(`Failed to process query "${sourceId}" using Jina DeepSearch: Unknown error`);
+    }
+  }
+}
+
+// Example of how to use the scraper (optional, for testing or demonstration)
+/*
+async function main() {
+  if (!Deno.env.get("JINA_API_KEY")) {
+    console.error("Please set the JINA_API_KEY environment variable.");
+    console.log("Get your Jina AI API key for free: https://jina.ai/?sui=apikey");
+    return;
+  }
+
+  const deepSearchScraper = new JinaDeepSearchScraper();
+  // Example query from Jina's DeepSearch documentation/examples if available
+  const searchQuery = "What are the recent advancements in AI-powered search engines?"; 
+
+  try {
+    console.log(`Attempting Jina DeepSearch for query: "${searchQuery}"`);
+    const contentItems = await deepSearchScraper.scrape(searchQuery, {
+      // Example of passing options, though not many are used by this scraper directly
+      // filters: { includeOriginalResponse: true } 
+    });
+
+    if (contentItems.length > 0) {
+      const item = contentItems[0];
+      console.log("\n--- Jina DeepSearch Result ---");
+      console.log("Title:", item.title);
+      console.log("ID:", item.id);
+      console.log("URL (Virtual):", item.url);
+      console.log("Publish Date:", item.publishDate);
+      
+      console.log("\nContent (Parsed):");
+      console.log(item.content.substring(0, 500) + (item.content.length > 500 ? "..." : ""));
+      
+      if (item.metadata.sources && item.metadata.sources.length > 0) {
+        console.log("\nSources found:");
+        item.metadata.sources.forEach((src: string, idx: number) => console.log(`[${idx+1}] ${src}`));
+      } else {
+        console.log("\nNo external sources explicitly listed in the response.");
+      }
+      
+      console.log("\nMetadata:", item.metadata);
+
+    } else {
+      console.log("No content items returned from Jina DeepSearch.");
+    }
+  } catch (error) {
+    console.error("\nError during Jina DeepSearch scraping example:", error.message);
+  }
+}
+
+// To run this example:
+// 1. Ensure JINA_API_KEY is set in your environment.
+// 2. Uncomment the following line and run the file with Deno: `deno run -A src/modules/scrapers/jina/jina.deepsearch.scraper.ts`
+// main();
+*/

--- a/src/modules/scrapers/jina/jina.scraper.ts
+++ b/src/modules/scrapers/jina/jina.scraper.ts
@@ -1,0 +1,161 @@
+// Get your Jina AI API key for free: https://jina.ai/?sui=apikey
+
+import {
+  ContentScraper,
+  ScrapedContent,
+  ScraperOptions,
+  Media,
+} from "@src/modules/interfaces/scraper.interface.ts";
+import { z } from "npm:zod@3.23.8";
+
+// Define a schema for the Jina API response for stricter parsing.
+const JinaResponseSchema = z.object({
+  code: z.number(),
+  status: z.number().optional(), // sometimes not present
+  data: z.object({
+    url: z.string(),
+    title: z.string(),
+    content: z.string(),
+    images: z.array(z.object({
+      src: z.string(),
+      alt: z.string().optional(),
+    })).optional(),
+    videos: z.array(z.object({
+      src: z.string(),
+      alt: z.string().optional(),
+    })).optional(),
+    // Add other fields from Jina response if needed
+  }),
+  usage: z.object({
+    total_tokens: z.number(),
+  }).optional(), // sometimes not present
+  message: z.string().optional(), // present on errors
+});
+
+export class JinaScraper implements ContentScraper {
+  private apiKey: string;
+  private jinaApiUrl = "https://r.jina.ai/";
+
+  constructor() {
+    const apiKey = Deno.env.get("JINA_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "JINA_API_KEY environment variable is not set. " +
+        "Get your Jina AI API key for free: https://jina.ai/?sui=apikey",
+      );
+    }
+    this.apiKey = apiKey;
+  }
+
+  async scrape(
+    sourceId: string, // This will be the URL to scrape
+    options?: ScraperOptions,
+  ): Promise<ScrapedContent[]> {
+    console.info(`[JinaScraper] Scraping URL: ${sourceId} with options: ${JSON.stringify(options)}`);
+
+    try {
+      const response = await fetch(this.jinaApiUrl + sourceId, { // Jina Reader API uses GET with URL in path
+        method: "GET", // Changed from POST to GET as per Jina Reader API docs (https://jina.ai/reader)
+        headers: {
+          "Authorization": `Bearer ${this.apiKey}`,
+          "Accept": "application/json",
+          // "X-With-Images-Summary": "true", // Example of an optional header
+        },
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(
+          `[JinaScraper] API request failed with status ${response.status}: ${errorBody}`,
+        );
+        throw new Error(
+          `Jina API request failed with status ${response.status}: ${errorBody}`,
+        );
+      }
+
+      const result = await response.json();
+      
+      // Validate the response structure
+      const parsedResult = JinaResponseSchema.safeParse(result);
+
+      if (!parsedResult.success) {
+        console.error(
+          `[JinaScraper] Invalid API response structure: ${parsedResult.error.toString()}`,
+          result
+        );
+        throw new Error(
+          `Jina API returned an invalid response structure. ${parsedResult.error.toString()}`,
+        );
+      }
+      
+      const jinaData = parsedResult.data.data;
+
+      const media: Media[] = [];
+      if (jinaData.images) {
+        jinaData.images.forEach(img => {
+          media.push({
+            url: img.src,
+            type: "image",
+            // Jina API doesn't provide size directly, so we omit it or set default
+            size: { width: 0, height: 0 }, 
+          });
+        });
+      }
+      // TODO: Add similar mapping for videos if needed
+
+      const scrapedContent: ScrapedContent = {
+        id: sourceId, // Using the URL as the ID
+        title: jinaData.title,
+        content: jinaData.content,
+        url: jinaData.url, // Jina provides the original URL back
+        publishDate: new Date().toISOString(), // Jina doesn't provide a publish date
+        media: media,
+        metadata: {
+          // Store any other relevant data from Jina's response
+          usage: parsedResult.data.usage, 
+        },
+      };
+
+      return [scrapedContent]; // The interface expects an array
+    } catch (error) {
+      console.error(`[JinaScraper] Error scraping ${sourceId}:`, error);
+      // Optionally, re-throw or return an empty array or specific error structure
+      if (error instanceof Error) {
+        throw new Error(`Failed to scrape ${sourceId} using Jina: ${error.message}`);
+      }
+      throw new Error(`Failed to scrape ${sourceId} using Jina: Unknown error`);
+    }
+  }
+}
+
+// Example of how to use the scraper (optional, for testing or demonstration)
+/*
+async function main() {
+  if (!Deno.env.get("JINA_API_KEY")) {
+    console.error("Please set the JINA_API_KEY environment variable.");
+    console.log("Get your Jina AI API key for free: https://jina.ai/?sui=apikey");
+    return;
+  }
+
+  const scraper = new JinaScraper();
+  const urlToScrape = "https://example.com"; // Replace with a real URL
+
+  try {
+    console.log(`Attempting to scrape: ${urlToScrape}`);
+    const content = await scraper.scrape(urlToScrape);
+    if (content.length > 0) {
+      console.log("Scraped Content:", content[0].title);
+      console.log(content[0].content.substring(0, 200) + "..."); // Print first 200 chars of content
+    } else {
+      console.log("No content scraped.");
+    }
+  } catch (error) {
+    console.error("Error during scraping example:", error);
+  }
+}
+
+// To run this example:
+// 1. Ensure JINA_API_KEY is set in your environment.
+// 2. Uncomment the following line and run the file with Deno: `deno run -A src/modules/scrapers/jina/jina.scraper.ts`
+// main();
+*/

--- a/src/modules/scrapers/jina/tests/jina.deepsearch.scraper.test.ts
+++ b/src/modules/scrapers/jina/tests/jina.deepsearch.scraper.test.ts
@@ -1,0 +1,257 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertNotEquals,
+} from "@std/assert/mod.ts";
+import { JinaDeepSearchScraper } from "../jina.deepsearch.scraper.ts";
+import { ScrapedContent } from "@src/modules/interfaces/scraper.interface.ts";
+
+// Store the original fetch function
+const originalFetch = globalThis.fetch;
+let mockFetch: ((input: URL | Request | string, init?: RequestInit) => Promise<Response>) | null = null;
+
+// Helper to mock globalThis.fetch
+function MOCK_FETCH(mock: (input: URL | Request | string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = mock;
+  mockFetch = mock;
+}
+
+// Helper to restore original fetch
+function RESTORE_FETCH() {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+  mockFetch = null;
+}
+
+const MOCK_JINA_API_KEY = "test-jina-api-key-deepsearch";
+
+Deno.test({
+  name: "[JinaDeepSearchScraper] Successful search with source parsing",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testQuery = "What is Deno?";
+    const mockResponseContent = 
+`Deno is a simple, modern and secure runtime for JavaScript and TypeScript.
+
+Sources:
+[1] https://deno.land/
+[Source 2] https://example.com/deno-article
+https://another-example.com/related`; // Test non-markdown link
+
+    const mockResponseData = {
+      id: "chatcmpl-mockid",
+      object: "chat.completion",
+      created: Date.now(),
+      model: "jina-deepsearch-v1",
+      choices: [{
+        index: 0,
+        message: {
+          role: "assistant",
+          content: mockResponseContent,
+        },
+        finish_reason: "stop",
+      }],
+      usage: { total_tokens: 50, prompt_tokens: 10, completion_tokens: 40 },
+    };
+
+    MOCK_FETCH(async (input: URL | Request | string, init?: RequestInit) => {
+      assertEquals(input, "https://deepsearch.jina.ai/v1/chat/completions");
+      assertEquals(init?.method, "POST");
+      assertEquals(init?.headers?.get("Authorization"), `Bearer ${MOCK_JINA_API_KEY}`);
+      const body = await init?.json();
+      assertEquals(body?.model, "jina-deepsearch-v1");
+      assertEquals(body?.messages[0]?.content, testQuery);
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const scraper = new JinaDeepSearchScraper();
+    const results: ScrapedContent[] = await scraper.scrape(testQuery);
+
+    assertEquals(results.length, 1);
+    const result = results[0];
+    assertStringIncludes(result.id, "jina-deepsearch-What is Deno?");
+    assertStringIncludes(result.title, 'Search Results for: "What is Deno?"');
+    assertEquals(result.content, "Deno is a simple, modern and secure runtime for JavaScript and TypeScript.");
+    assertStringIncludes(result.url, `jina-deepsearch://query?${encodeURIComponent(testQuery)}`);
+    assert(result.publishDate); 
+    assertEquals(result.media?.length, 0); // No media expected
+    
+    assertEquals(result.metadata?.query, testQuery);
+    assertEquals(result.metadata?.model, "jina-deepsearch-v1");
+    assertEquals(result.metadata?.usage?.total_tokens, 50);
+    assert(Array.isArray(result.metadata?.sources));
+    assertEquals(result.metadata?.sources?.length, 3);
+    assertEquals(result.metadata?.sources?.[0], "https://deno.land/");
+    assertEquals(result.metadata?.sources?.[1], "https://example.com/deno-article");
+    assertEquals(result.metadata?.sources?.[2], "https://another-example.com/related");
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaDeepSearchScraper] Successful search - no sources section",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testQuery = "Tell me about Deno";
+    const mockResponseContent = "Deno is a runtime for JavaScript and TypeScript. No sources listed here.";
+    const mockResponseData = { /* ... structure like above ... */ 
+        model: "jina-deepsearch-v1", 
+        choices: [{ index: 0, message: { role: "assistant", content: mockResponseContent }, finish_reason: "stop" }]
+    };
+
+    MOCK_FETCH(async (_input, _init) => Promise.resolve(new Response(JSON.stringify(mockResponseData), { status: 200 })));
+
+    const scraper = new JinaDeepSearchScraper();
+    const results = await scraper.scrape(testQuery);
+    
+    assertEquals(results.length, 1);
+    assertEquals(results[0].content, mockResponseContent);
+    assertEquals(results[0].metadata?.sources?.length, 0);
+
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  }
+});
+
+
+Deno.test({
+  name: "[JinaDeepSearchScraper] API Error (500)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testQuery = "Query causing server error";
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+    });
+
+    const scraper = new JinaDeepSearchScraper();
+    await assertRejects(
+      () => scraper.scrape(testQuery),
+      Error,
+      "Jina DeepSearch API request failed with status 500: Internal Server Error",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+    name: "[JinaDeepSearchScraper] API Error with Jina specific JSON (e.g. 422 Unprocessable Entity)",
+    async fn() {
+      Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+      const testQuery = "Invalid query for Jina";
+      const errorJson = { error: { message: "Request validation error", type: "invalid_request_error", code: "invalid_query" } };
+  
+      MOCK_FETCH(async (_input, _init) => {
+        return Promise.resolve(new Response(JSON.stringify(errorJson), { status: 422, headers: { "Content-Type": "application/json" } }));
+      });
+  
+      const scraper = new JinaDeepSearchScraper();
+      await assertRejects(
+        () => scraper.scrape(testQuery),
+        Error,
+        "Jina DeepSearch API Error: Request validation error (Status: 422)",
+      );
+      
+      RESTORE_FETCH();
+      Deno.env.delete("JINA_API_KEY");
+    },
+  });
+
+Deno.test({
+  name: "[JinaDeepSearchScraper] Response Validation Error (Malformed JSON)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testQuery = "Query leading to malformed response";
+    const malformedResponse = {
+      // Missing 'choices' or 'choices[0].message.content'
+      model: "jina-deepsearch-v1",
+      unexpected_field: "unexpected_value",
+    };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(malformedResponse), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const scraper = new JinaDeepSearchScraper();
+    await assertRejects(
+      () => scraper.scrape(testQuery),
+      Error, 
+      "Jina DeepSearch API returned an invalid response structure.",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+
+Deno.test({
+  name: "[JinaDeepSearchScraper] API returns no choices",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testQuery = "Query with no choices";
+    const mockResponseData = {
+      model: "jina-deepsearch-v1",
+      choices: [], // Empty choices array
+      usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+    };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const scraper = new JinaDeepSearchScraper();
+    const results = await scraper.scrape(testQuery);
+    assertEquals(results.length, 0); // Expect empty array, not an error
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+
+Deno.test({
+  name: "[JinaDeepSearchScraper] Constructor API Key Check (Missing)",
+  fn() {
+    Deno.env.delete("JINA_API_KEY");
+    assertRejects(
+      () => { new JinaDeepSearchScraper(); },
+      Error,
+      "JINA_API_KEY environment variable is not set.",
+    );
+  },
+});
+
+Deno.test({
+    name: "[JinaDeepSearchScraper] Constructor API Key Check (Present)",
+    fn() {
+      Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+      try {
+        new JinaDeepSearchScraper();
+      } catch (e) {
+        assert(false, `Should not throw when API key is present: ${e.message}`);
+      } finally {
+        Deno.env.delete("JINA_API_KEY");
+      }
+    },
+  });
+
+// Safeguard teardown
+globalThis.addEventListener("unload", () => {
+    if (mockFetch) {
+        RESTORE_FETCH();
+    }
+});

--- a/src/modules/scrapers/jina/tests/jina.scraper.test.ts
+++ b/src/modules/scrapers/jina/tests/jina.scraper.test.ts
@@ -1,0 +1,196 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert/mod.ts";
+import { JinaScraper } from "../jina.scraper.ts";
+import { ScrapedContent } from "@src/modules/interfaces/scraper.interface.ts";
+
+// Store the original fetch function
+const originalFetch = globalThis.fetch;
+let mockFetch: ((input: URL | Request | string, init?: RequestInit) => Promise<Response>) | null = null;
+
+// Helper to mock globalThis.fetch
+function MOCK_FETCH(mock: (input: URL | Request | string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = mock;
+  mockFetch = mock;
+}
+
+// Helper to restore original fetch
+function RESTORE_FETCH() {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+  mockFetch = null;
+}
+
+const MOCK_JINA_API_KEY = "test-jina-api-key";
+
+Deno.test({
+  name: "[JinaScraper] Successful scrape",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testUrl = "https://example.com/article";
+    const mockResponseData = {
+      code: 200,
+      status: 200,
+      data: {
+        url: testUrl,
+        title: "Test Article Title",
+        content: "This is the article content.",
+        images: [{ src: "https://example.com/image.png", alt: "Test Image" }],
+      },
+      usage: { total_tokens: 100 },
+    };
+
+    MOCK_FETCH(async (input: URL | Request | string, _init?: RequestInit) => {
+      assertEquals(input, `https://r.jina.ai/${testUrl}`);
+      assertEquals(_init?.headers?.get("Authorization"), `Bearer ${MOCK_JINA_API_KEY}`);
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const scraper = new JinaScraper();
+    const results: ScrapedContent[] = await scraper.scrape(testUrl);
+
+    assertEquals(results.length, 1);
+    const result = results[0];
+    assertEquals(result.id, testUrl);
+    assertEquals(result.url, testUrl);
+    assertEquals(result.title, "Test Article Title");
+    assertEquals(result.content, "This is the article content.");
+    assert(result.publishDate); // Should be current date string
+    assertEquals(result.media?.length, 1);
+    assertEquals(result.media?.[0].url, "https://example.com/image.png");
+    assertEquals(result.media?.[0].type, "image");
+    assertEquals(result.metadata?.usage, { total_tokens: 100 });
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaScraper] API Error (500)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testUrl = "https://example.com/internal-error";
+
+    MOCK_FETCH(async (input: URL | Request | string, _init?: RequestInit) => {
+      assertEquals(input, `https://r.jina.ai/${testUrl}`);
+      return Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+    });
+
+    const scraper = new JinaScraper();
+    await assertRejects(
+      async () => {
+        await scraper.scrape(testUrl);
+      },
+      Error,
+      "Jina API request failed with status 500: Internal Server Error",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaScraper] API Error (401 Unauthorized)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testUrl = "https://example.com/unauthorized";
+
+    MOCK_FETCH(async (input: URL | Request | string, _init?: RequestInit) => {
+        assertEquals(input, `https://r.jina.ai/${testUrl}`);
+        return Promise.resolve(new Response("Unauthorized", { status: 401 }));
+    });
+
+    const scraper = new JinaScraper();
+    await assertRejects(
+        async () => {
+            await scraper.scrape(testUrl);
+        },
+        Error,
+        "Jina API request failed with status 401: Unauthorized",
+    );
+
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+
+Deno.test({
+  name: "[JinaScraper] Response Validation Error (Malformed JSON)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testUrl = "https://example.com/malformed";
+    const malformedResponse = {
+      code: 200,
+      data: {
+        // Missing 'title', 'content', 'url' which are required by JinaResponseSchema
+        unexpected_field: "unexpected_value",
+      },
+    };
+
+    MOCK_FETCH(async (input: URL | Request | string, _init?: RequestInit) => {
+      assertEquals(input, `https://r.jina.ai/${testUrl}`);
+      return Promise.resolve(
+        new Response(JSON.stringify(malformedResponse), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const scraper = new JinaScraper();
+    await assertRejects(
+      async () => {
+        await scraper.scrape(testUrl);
+      },
+      Error, // Zod errors are typically wrapped in a generic Error by the implementation
+      "Jina API returned an invalid response structure.", // Check for part of the message
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaScraper] Constructor API Key Check (Missing)",
+  fn() {
+    Deno.env.delete("JINA_API_KEY"); // Ensure key is not set
+    
+    assertRejects(
+      () => {
+        new JinaScraper();
+      },
+      Error,
+      "JINA_API_KEY environment variable is not set.",
+    );
+  },
+});
+
+Deno.test({
+    name: "[JinaScraper] Constructor API Key Check (Present)",
+    fn() {
+      Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+      try {
+        new JinaScraper();
+        // No error expected
+      } catch (e) {
+        assert(false, `Should not throw when API key is present: ${e.message}`);
+      } finally {
+        Deno.env.delete("JINA_API_KEY");
+      }
+    },
+  });
+
+// Teardown for all tests in this file, if mockFetch was not restored properly in a test.
+// This is a safeguard.
+globalThis.addEventListener("unload", () => {
+    if (mockFetch) {
+        RESTORE_FETCH();
+    }
+});

--- a/src/modules/scrapers/scraper-factory.ts
+++ b/src/modules/scrapers/scraper-factory.ts
@@ -1,0 +1,186 @@
+import { ContentScraper, ScraperOptions } from "@src/modules/interfaces/scraper.interface.ts";
+import { ConfigManager } from "@src/utils/config/config-manager.ts"; // May not be needed if scrapers self-configure from env
+
+// Import available scrapers
+import { JinaScraper } from "./jina/jina.scraper.ts";
+import { JinaDeepSearchScraper } from "./jina/jina.deepsearch.scraper.ts";
+import { FireCrawlScraper } from "./fireCrawl.scraper.ts";
+import { RsshubScraper } from "./rsshub.scraper.ts";
+import { HellogithubScraper } from "./hellogithub.scraper.ts";
+import { TwitterScraper } from "./twitter.scraper.ts";
+
+/**
+ * Scraper Provider Type Enum
+ * Using strings directly for now, can be converted to enum if preferred
+ */
+export enum ScraperType {
+  JINA_READER = "JINA_READER", // For JinaScraper (URL scraping)
+  JINA_DEEPSEARCH = "JINA_DEEPSEARCH",
+  FIRECRAWL = "FIRECRAWL",
+  RSSHUB = "RSSHUB",
+  HELLOGITHUB = "HELLOGITHUB",
+  TWITTER = "TWITTER",
+  // Add other scraper types here
+}
+
+/**
+ * Scraper Provider Type Map
+ * Maps ScraperType to the corresponding scraper class.
+ */
+export interface ScraperTypeMap {
+  [ScraperType.JINA_READER]: JinaScraper;
+  [ScraperType.JINA_DEEPSEARCH]: JinaDeepSearchScraper;
+  [ScraperType.FIRECRAWL]: FireCrawlScraper;
+  [ScraperType.RSSHUB]: RsshubScraper;
+  [ScraperType.HELLOGITHUB]: HellogithubScraper;
+  [ScraperType.TWITTER]: TwitterScraper;
+}
+
+/**
+ * Parsed Scraper Configuration
+ * For scrapers, this might be simpler than embeddings, primarily just the type.
+ * Additional constructor parameters could be added if scrapers need them.
+ */
+interface ParsedScraperConfig {
+  scraperType: ScraperType;
+  // configKey?: string; // If scrapers needed specific config keys from ConfigManager
+}
+
+/**
+ * Scraper Factory Class
+ */
+export class ScraperFactory {
+  private static instance: ScraperFactory;
+  private scrapers: Map<string, ContentScraper> = new Map();
+  // private configManager: ConfigManager; // Uncomment if scrapers need centralized config
+
+  private constructor() {
+    // this.configManager = ConfigManager.getInstance(); // Uncomment if needed
+  }
+
+  public static getInstance(): ScraperFactory {
+    if (!ScraperFactory.instance) {
+      ScraperFactory.instance = new ScraperFactory();
+    }
+    return ScraperFactory.instance;
+  }
+
+  /**
+   * Parses the scraper configuration string (which is just the type for now)
+   * @param typeOrConfig Scraper type string or a ParsedScraperConfig object
+   */
+  private parseConfig(typeOrConfig: ScraperType | string | ParsedScraperConfig): ParsedScraperConfig {
+    if (typeof typeOrConfig === 'object' && 'scraperType' in typeOrConfig) {
+        return typeOrConfig as ParsedScraperConfig;
+    }
+    const scraperType = typeOrConfig as ScraperType;
+    if (!Object.values(ScraperType).includes(scraperType)) {
+        throw new Error(`Unsupported ScraperType: ${scraperType}`);
+    }
+    return { scraperType };
+  }
+  
+  private getProviderCacheKey(config: ParsedScraperConfig): string {
+    // For scrapers, the type is usually sufficient as a cache key,
+    // unless they have constructor params affecting their instance (e.g. different base URLs for RSSHub).
+    return config.scraperType;
+  }
+
+  /**
+   * Gets or creates a scraper instance.
+   * Scrapers typically don't have complex initialization or refresh logic like LLM/Embedding providers.
+   * @param typeOrConfig ScraperType string or ParsedScraperConfig
+   */
+  public getScraper<T extends ParsedScraperConfig>(
+    typeOrConfig: T | ScraperType | string,
+  ): ScraperTypeMap[T["scraperType"]] {
+    
+    const config = this.parseConfig(typeOrConfig);
+    const cacheKey = this.getProviderCacheKey(config);
+
+    if (this.scrapers.has(cacheKey)) {
+      return this.scrapers.get(cacheKey)! as ScraperTypeMap[T["scraperType"]];
+    }
+
+    const scraper = this.createScraper(config);
+    // Most scrapers don't have an async initialize() method. If they did, this would need to be async.
+    // For now, assuming synchronous constructor and setup.
+    this.scrapers.set(cacheKey, scraper);
+    return scraper as ScraperTypeMap[T["scraperType"]];
+  }
+
+  private createScraper(config: ParsedScraperConfig): ContentScraper {
+    switch (config.scraperType) {
+      case ScraperType.JINA_READER:
+        return new JinaScraper(); // Assumes JinaScraper constructor takes no args or handles defaults
+      case ScraperType.JINA_DEEPSEARCH:
+        return new JinaDeepSearchScraper(); // Assumes JinaDeepSearchScraper constructor takes no args
+      case ScraperType.FIRECRAWL:
+        return new FireCrawlScraper(); // Assuming constructor takes no args or uses env vars
+      case ScraperType.RSSHUB:
+        return new RsshubScraper(); // Assuming constructor takes no args
+      case ScraperType.HELLOGITHUB:
+        return new HellogithubScraper();
+      case ScraperType.TWITTER:
+        // TwitterScraper might take arguments if it needs API keys/tokens passed directly
+        // For now, assuming it reads from env like others or has a default config.
+        // If it needs params: new TwitterScraper(this.configManager.get('TWITTER_API_KEY'));
+        return new TwitterScraper(); 
+      default:
+        // This should ideally be caught by parseConfig, but as a safeguard:
+        const exhaustiveCheck: never = config.scraperType;
+        throw new Error(`Unhandled ScraperType in createScraper: ${exhaustiveCheck}`);
+    }
+  }
+}
+
+// Example Usage (optional, for testing or demonstration within this file)
+/*
+async function mainFactoryTest() {
+  // This requires environment variables for Jina, Firecrawl etc. to be set
+  // to fully test the underlying scrapers' functionality.
+  // Here we are just testing the factory instantiation.
+
+  try {
+    const factory = ScraperFactory.getInstance();
+
+    console.log("Attempting to get JINA_READER scraper...");
+    const jinaReader = factory.getScraper(ScraperType.JINA_READER);
+    console.log("JINA_READER scraper instance:", jinaReader instanceof JinaScraper ? "OK" : "Failed");
+    // await jinaReader.scrape("https://example.com"); // Requires JINA_API_KEY
+
+    console.log("\nAttempting to get JINA_DEEPSEARCH scraper...");
+    const jinaDeepSearch = factory.getScraper(ScraperType.JINA_DEEPSEARCH);
+    console.log("JINA_DEEPSEARCH scraper instance:", jinaDeepSearch instanceof JinaDeepSearchScraper ? "OK" : "Failed");
+    // await jinaDeepSearch.scrape("What is Deno?"); // Requires JINA_API_KEY
+
+    console.log("\nAttempting to get FIRECRAWL scraper...");
+    const firecrawlScraper = factory.getScraper(ScraperType.FIRECRAWL);
+    console.log("FIRECRAWL scraper instance:", firecrawlScraper instanceof FireCrawlScraper ? "OK" : "Failed");
+    // await firecrawlScraper.scrape("https://deno.land"); // Requires FIRECRAWL_API_KEY
+
+    console.log("\nAttempting to get RSSHUB scraper...");
+    const rsshubScraper = factory.getScraper(ScraperType.RSSHUB);
+    console.log("RSSHUB scraper instance:", rsshubScraper instanceof RsshubScraper ? "OK" : "Failed");
+    // await rsshubScraper.scrape("/github/trending/daily/javascript"); // Example RSSHub path
+
+    console.log("\nAttempting to get HELLOGITHUB scraper...");
+    const helloGithubScraper = factory.getScraper(ScraperType.HELLOGITHUB);
+    console.log("HELLOGITHUB scraper instance:", helloGithubScraper instanceof HellogithubScraper ? "OK" : "Failed");
+     // await helloGithubScraper.scrape("some_source_id_if_needed");
+
+    console.log("\nAttempting to get TWITTER scraper...");
+    const twitterScraper = factory.getScraper(ScraperType.TWITTER);
+    console.log("TWITTER scraper instance:", twitterScraper instanceof TwitterScraper ? "OK" : "Failed");
+     // await twitterScraper.scrape("elonmusk"); // Example Twitter username
+
+  } catch (error) {
+    console.error("\nError during ScraperFactory test:", error.message);
+  }
+}
+
+// To run this example:
+// 1. Ensure necessary API keys (JINA_API_KEY, etc.) are set if you uncomment scrape calls.
+// 2. Uncomment the following line and run: `deno run -A src/modules/scrapers/scraper-factory.ts`
+// mainFactoryTest();
+*/

--- a/src/providers/embedding/embedding-factory.ts
+++ b/src/providers/embedding/embedding-factory.ts
@@ -1,5 +1,6 @@
 import { EmbeddingProvider, EmbeddingProviderType, EmbeddingProviderTypeMap } from "@src/providers/interfaces/embedding.interface.ts";
 import { OpenAICompatibleEmbedding } from "@src/providers/embedding/openai-compatible-embedding.ts";
+import { JinaEmbeddingProvider } from "./jina/jina.embedding.ts"; // Corrected path
 import { ConfigManager } from "@src/utils/config/config-manager.ts";
 
 /**
@@ -107,6 +108,8 @@ export class EmbeddingFactory {
         return new OpenAICompatibleEmbedding("DASHSCOPE_", this.configManager, config.model);
       case EmbeddingProviderType.CUSTOM:
         return new OpenAICompatibleEmbedding("CUSTOM_", this.configManager, config.model);
+      case EmbeddingProviderType.JINA:
+        return new JinaEmbeddingProvider({ model: config.model }); // Pass model to Jina provider
       default:
         throw new Error(`不支持的 Embedding Provider 类型: ${config.providerType}`);
     }

--- a/src/providers/embedding/jina/jina.embedding.ts
+++ b/src/providers/embedding/jina/jina.embedding.ts
@@ -1,0 +1,209 @@
+// Get your Jina AI API key for free: https://jina.ai/?sui=apikey
+
+import {
+  EmbeddingProvider,
+  EmbeddingOptions,
+  EmbeddingResult,
+} from "@src/providers/interfaces/embedding.interface.ts";
+import { z } from "npm:zod@3.23.8";
+
+// Zod Schema for Jina Embeddings API Request
+const JinaEmbeddingRequestSchema = z.object({
+  model: z.string(),
+  input: z.array(z.string()),
+  encoding_format: z.enum(["float", "base64"]).optional(),
+  // Jina also supports 'dimensions' for some models, could be added to EmbeddingOptions
+});
+
+// Zod Schema for a single embedding object in the Jina API Response
+const JinaEmbeddingObjectSchema = z.object({
+  object: z.string().optional(), // e.g., "embedding"
+  embedding: z.array(z.number()),
+  index: z.number(),
+});
+
+// Zod Schema for Jina Embeddings API Response
+const JinaEmbeddingResponseSchema = z.object({
+  model: z.string(),
+  data: z.array(JinaEmbeddingObjectSchema),
+  usage: z.object({
+    total_tokens: z.number(),
+    prompt_tokens: z.number().optional(), // Some models might not return this
+  }),
+});
+
+export interface JinaEmbeddingProviderConfig {
+  model?: string; // Default: "jina-embeddings-v2-base-en"
+  // other Jina specific configurations can be added here
+}
+
+export class JinaEmbeddingProvider implements EmbeddingProvider {
+  private apiKey: string;
+  private defaultModel: string;
+  private jinaApiUrl = "https://api.jina.ai/v1/embeddings";
+
+  constructor(config?: JinaEmbeddingProviderConfig) {
+    const apiKey = Deno.env.get("JINA_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "JINA_API_KEY environment variable is not set. " +
+        "Get your Jina AI API key for free: https://jina.ai/?sui=apikey",
+      );
+    }
+    this.apiKey = apiKey;
+    this.defaultModel = config?.model || "jina-embeddings-v2-base-en"; // A common default Jina model
+  }
+
+  async initialize(): Promise<void> {
+    // No specific initialization needed for Jina embeddings if API key is set
+    return Promise.resolve();
+  }
+
+  async refresh(): Promise<void> {
+    // No specific refresh logic needed unless config can change dynamically
+    return Promise.resolve();
+  }
+
+  async createEmbedding(
+    text: string,
+    options?: EmbeddingOptions,
+  ): Promise<EmbeddingResult> {
+    const model = options?.model || this.defaultModel;
+    const encoding_format = options?.encoding_format || "float";
+
+    // Jina API expects 'input' to be an array of strings.
+    // The interface provides a single 'text', so we wrap it in an array.
+    const requestBody = JinaEmbeddingRequestSchema.parse({
+      model: model,
+      input: [text],
+      encoding_format: encoding_format,
+      // If options.dimensions is provided, and the chosen Jina model supports it,
+      // it could be passed here. For example, some models accept a `dimensions` parameter.
+      // However, the Jina API documentation for the /v1/embeddings endpoint
+      // doesn't list `dimensions` as a top-level request parameter.
+      // It's usually tied to the model choice itself or specific newer models.
+    });
+
+    console.info(`[JinaEmbeddingProvider] Creating embedding for text (first 50 chars): "${text.substring(0,50)}..." with model: ${model}`);
+
+    try {
+      const response = await fetch(this.jinaApiUrl, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(
+          `[JinaEmbeddingProvider] API request failed with status ${response.status}: ${errorBody}`,
+        );
+        // Attempt to parse Jina specific error structure if available
+        try {
+            const errJson = JSON.parse(errorBody);
+            if (errJson && errJson.detail) { // Jina errors often have a "detail" field
+                 throw new Error(`Jina Embeddings API Error: ${errJson.detail} (Status: ${response.status})`);
+            }
+        } catch (e) { /* ignore parsing error, throw original text */ }
+        throw new Error(
+          `Jina Embeddings API request failed with status ${response.status}: ${errorBody}`,
+        );
+      }
+
+      const result = await response.json();
+      const parsedResult = JinaEmbeddingResponseSchema.safeParse(result);
+
+      if (!parsedResult.success) {
+        console.error(
+          `[JinaEmbeddingProvider] Invalid API response structure: ${parsedResult.error.toString()}`,
+          result
+        );
+        throw new Error(
+          `Jina Embeddings API returned an invalid response structure. ${parsedResult.error.toString()}`,
+        );
+      }
+      
+      const apiData = parsedResult.data;
+
+      if (!apiData.data || apiData.data.length === 0 || !apiData.data[0].embedding) {
+        console.warn("[JinaEmbeddingProvider] API returned no embedding data.", apiData);
+        throw new Error("Jina Embeddings API returned no embedding data.");
+      }
+
+      const embeddingData = apiData.data[0]; // Since we send one text, we expect one embedding object
+
+      return {
+        embedding: embeddingData.embedding,
+        model: apiData.model, // The model actually used by Jina
+        dimensions: embeddingData.embedding.length, // Derived from the embedding vector
+      };
+
+    } catch (error) {
+      console.error(`[JinaEmbeddingProvider] Error creating embedding for text "${text.substring(0,50)}...":`, error);
+      if (error instanceof Error) {
+        throw new Error(`Failed to create embedding using Jina: ${error.message}`);
+      }
+      throw new Error(`Failed to create embedding using Jina: Unknown error`);
+    }
+  }
+}
+
+// Example of how to use the provider (optional, for testing or demonstration)
+/*
+async function main() {
+  if (!Deno.env.get("JINA_API_KEY")) {
+    console.error("Please set the JINA_API_KEY environment variable.");
+    console.log("Get your Jina AI API key for free: https://jina.ai/?sui=apikey");
+    return;
+  }
+
+  // Instantiate without specific config (uses default model)
+  const embeddingProvider = new JinaEmbeddingProvider();
+  
+  // Or with specific config
+  // const embeddingProviderWithConfig = new JinaEmbeddingProvider({ model: "jina-embeddings-v2-small-en" });
+
+
+  const textToEmbed = "Hello from Jina Embeddings!";
+  
+  try {
+    console.log(`Attempting to create embedding for: "${textToEmbed}"`);
+    
+    // Using default model from provider
+    let result = await embeddingProvider.createEmbedding(textToEmbed);
+    console.log("\n--- Embedding Result (Default Model) ---");
+    console.log("Model Used:", result.model);
+    console.log("Dimensions:", result.dimensions);
+    console.log("Embedding (first 5 values):", result.embedding.slice(0, 5));
+    console.log(`Total ${result.embedding.length} values.`);
+
+    // Example: Overriding model and options via createEmbedding options
+    // Note: Jina might have different model identifiers for different capabilities
+    // For example, 'jina-embeddings-v2-base-en' is a common one.
+    // 'jina-embeddings-v3-base' or similar for newer versions.
+    const customOptions: EmbeddingOptions = {
+        model: "jina-embeddings-v2-small-en", // Example of a different Jina model
+        // encoding_format: "base64" // if needed
+    };
+    console.log(`\nAttempting to create embedding with custom options: Model ${customOptions.model}`);
+    result = await embeddingProvider.createEmbedding(textToEmbed, customOptions);
+    console.log("\n--- Embedding Result (Custom Options) ---");
+    console.log("Model Used:", result.model); // Will be the one Jina actually used
+    console.log("Dimensions:", result.dimensions);
+    console.log("Embedding (first 5 values):", result.embedding.slice(0, 5));
+
+
+  } catch (error) {
+    console.error("\nError during Jina Embedding example:", error.message);
+  }
+}
+
+// To run this example:
+// 1. Ensure JINA_API_KEY is set in your environment.
+// 2. Uncomment the following line and run the file with Deno: `deno run -A src/providers/embedding/jina/jina.embedding.ts`
+// main();
+*/

--- a/src/providers/embedding/jina/tests/jina.embedding.test.ts
+++ b/src/providers/embedding/jina/tests/jina.embedding.test.ts
@@ -1,0 +1,278 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertNotEquals,
+} from "@std/assert/mod.ts";
+import { JinaEmbeddingProvider } from "../jina.embedding.ts";
+import { EmbeddingResult, EmbeddingOptions } from "@src/providers/interfaces/embedding.interface.ts";
+
+// Store the original fetch function
+const originalFetch = globalThis.fetch;
+let mockFetch: ((input: URL | Request | string, init?: RequestInit) => Promise<Response>) | null = null;
+
+// Helper to mock globalThis.fetch
+function MOCK_FETCH(mock: (input: URL | Request | string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = mock;
+  mockFetch = mock;
+}
+
+// Helper to restore original fetch
+function RESTORE_FETCH() {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+  mockFetch = null;
+}
+
+const MOCK_JINA_API_KEY = "test-jina-api-key-embedding";
+const DEFAULT_MODEL = "jina-embeddings-v2-base-en";
+const CUSTOM_MODEL = "jina-embeddings-v2-small-en";
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] Successful embedding creation (default model)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "This is a test text for embedding.";
+    const mockEmbeddingVector = Array.from({length: 768}, () => Math.random()); // Example dim for v2-base
+
+    const mockResponseData = {
+      model: DEFAULT_MODEL,
+      data: [{
+        object: "embedding",
+        embedding: mockEmbeddingVector,
+        index: 0,
+      }],
+      usage: { total_tokens: 10, prompt_tokens: 10 },
+    };
+
+    MOCK_FETCH(async (input: URL | Request | string, init?: RequestInit) => {
+      assertEquals(input, "https://api.jina.ai/v1/embeddings");
+      assertEquals(init?.method, "POST");
+      assertEquals(init?.headers?.get("Authorization"), `Bearer ${MOCK_JINA_API_KEY}`);
+      const body = await init?.json();
+      assertEquals(body?.model, DEFAULT_MODEL);
+      assertEquals(body?.input, [testText]);
+      assertEquals(body?.encoding_format, "float");
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const provider = new JinaEmbeddingProvider(); // Uses default model
+    const result: EmbeddingResult = await provider.createEmbedding(testText);
+
+    assertEquals(result.embedding, mockEmbeddingVector);
+    assertEquals(result.model, DEFAULT_MODEL);
+    assertEquals(result.dimensions, mockEmbeddingVector.length);
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] Successful embedding with model option in constructor",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "Another test text.";
+    const mockEmbeddingVector = Array.from({length: 512}, () => Math.random()); // Example dim for v2-small
+
+    const mockResponseData = {
+      model: CUSTOM_MODEL, // Jina returns the model it used
+      data: [{ embedding: mockEmbeddingVector, index: 0 }],
+      usage: { total_tokens: 5 }
+    };
+
+    MOCK_FETCH(async (_input, init) => {
+      const body = await init?.json();
+      assertEquals(body?.model, CUSTOM_MODEL); // Check if provider sent the custom model
+      return Promise.resolve(new Response(JSON.stringify(mockResponseData), { status: 200 }));
+    });
+
+    const provider = new JinaEmbeddingProvider({ model: CUSTOM_MODEL });
+    const result = await provider.createEmbedding(testText);
+
+    assertEquals(result.model, CUSTOM_MODEL);
+    assertEquals(result.dimensions, mockEmbeddingVector.length);
+
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  }
+});
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] Successful embedding with model and encoding_format options in createEmbedding",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "Text with custom options.";
+    const mockEmbeddingVectorBase64 = ["dGVzdAo=", "ZW1iZWRkaW5nCg=="]; // Dummy base64 strings
+     // For base64, the 'embedding' field in EmbeddingResult should still be number[] after decoding.
+     // However, Jina API returns base64 strings. The current interface expects number[].
+     // This test will assume the provider *does not* decode base64, as the interface is number[].
+     // If it *should* decode, this test and the provider need adjustment.
+     // For now, let's assume Jina API with encoding_format='base64' returns string[], and our provider would fail validation.
+     // Let's test with 'float' and custom model via options.
+
+    const mockEmbeddingVectorFloat = Array.from({length: 512}, () => Math.random());
+    const mockResponseDataFloat = {
+      model: CUSTOM_MODEL,
+      data: [{ embedding: mockEmbeddingVectorFloat, index: 0 }],
+      usage: { total_tokens: 6 }
+    };
+
+    MOCK_FETCH(async (_input, init) => {
+      const body = await init?.json();
+      assertEquals(body?.model, CUSTOM_MODEL);
+      assertEquals(body?.encoding_format, "float"); // Test if option is passed
+      return Promise.resolve(new Response(JSON.stringify(mockResponseDataFloat), { status: 200 }));
+    });
+    
+    const provider = new JinaEmbeddingProvider(); // Default model initially
+    const options: EmbeddingOptions = { model: CUSTOM_MODEL, encoding_format: "float" };
+    const result = await provider.createEmbedding(testText, options);
+
+    assertEquals(result.model, CUSTOM_MODEL);
+    assertEquals(result.dimensions, mockEmbeddingVectorFloat.length);
+
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  }
+});
+
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] API Error (500)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "Text causing server error";
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+    });
+
+    const provider = new JinaEmbeddingProvider();
+    await assertRejects(
+      () => provider.createEmbedding(testText),
+      Error,
+      "Jina Embeddings API request failed with status 500: Internal Server Error",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] API Error with Jina specific JSON detail",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "Text causing Jina error";
+    const errorJson = { detail: "Invalid model requested" };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(new Response(JSON.stringify(errorJson), { status: 422, headers: { "Content-Type": "application/json" } }));
+    });
+
+    const provider = new JinaEmbeddingProvider();
+    await assertRejects(
+      () => provider.createEmbedding(testText),
+      Error,
+      "Jina Embeddings API Error: Invalid model requested (Status: 422)",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] Response Validation Error (Malformed JSON)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "Text leading to malformed response";
+    const malformedResponse = {
+      // Missing 'model' or 'data'
+      unexpected_field: "unexpected_value",
+    };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(malformedResponse), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const provider = new JinaEmbeddingProvider();
+    await assertRejects(
+      () => provider.createEmbedding(testText),
+      Error, 
+      "Jina Embeddings API returned an invalid response structure.",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] API returns no embedding data in array",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const testText = "Query with no data returned";
+    const mockResponseData = {
+      model: DEFAULT_MODEL,
+      data: [], // Empty data array
+      usage: { total_tokens: 5, prompt_tokens: 5 },
+    };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const provider = new JinaEmbeddingProvider();
+    await assertRejects(
+        () => provider.createEmbedding(testText),
+        Error,
+        "Jina Embeddings API returned no embedding data."
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+
+Deno.test({
+  name: "[JinaEmbeddingProvider] Constructor API Key Check (Missing)",
+  fn() {
+    Deno.env.delete("JINA_API_KEY");
+    assertRejects(
+      () => { new JinaEmbeddingProvider(); },
+      Error,
+      "JINA_API_KEY environment variable is not set.",
+    );
+  },
+});
+
+Deno.test({
+    name: "[JinaEmbeddingProvider] Constructor API Key Check (Present)",
+    fn() {
+      Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+      try {
+        new JinaEmbeddingProvider();
+      } catch (e) {
+        assert(false, `Should not throw when API key is present: ${e.message}`);
+      } finally {
+        Deno.env.delete("JINA_API_KEY");
+      }
+    },
+  });
+
+// Safeguard teardown
+globalThis.addEventListener("unload", () => {
+    if (mockFetch) {
+        RESTORE_FETCH();
+    }
+});

--- a/src/providers/interfaces/embedding.interface.ts
+++ b/src/providers/interfaces/embedding.interface.ts
@@ -44,7 +44,8 @@ export interface EmbeddingResult {
 export enum EmbeddingProviderType {
   OPENAI = "OPENAI",
   DASHSCOPE = "DASHSCOPE",
-  CUSTOM = "CUSTOM"
+  CUSTOM = "CUSTOM",
+  JINA = "JINA" // Added Jina
 }
 
 /**
@@ -54,4 +55,5 @@ export interface EmbeddingProviderTypeMap {
   [EmbeddingProviderType.OPENAI]: import("../embedding/openai-compatible-embedding.ts").OpenAICompatibleEmbedding;
   [EmbeddingProviderType.DASHSCOPE]: import("../embedding/openai-compatible-embedding.ts").OpenAICompatibleEmbedding;
   [EmbeddingProviderType.CUSTOM]: import("../embedding/openai-compatible-embedding.ts").OpenAICompatibleEmbedding;
+  [EmbeddingProviderType.JINA]: import("../embedding/jina/jina.embedding.ts").JinaEmbeddingProvider; // Added Jina
 } 

--- a/src/providers/interfaces/reranker.interface.ts
+++ b/src/providers/interfaces/reranker.interface.ts
@@ -1,0 +1,38 @@
+/**
+ * Reranker Provider Interface
+ */
+
+export interface RerankedDocument {
+  document: string; // Or the original document type if complex
+  index: number;    // Original index of the document in the input array
+  relevanceScore: number;
+}
+
+export interface RerankerOptions {
+  topN?: number;
+  model?: string; // Allow specifying model at call time
+  returnDocuments?: boolean; // Jina specific: whether to return the document text in the response
+}
+
+export interface RerankerProvider {
+  /**
+   * Reranks a list of documents based on a query.
+   * @param query The query string.
+   * @param documents An array of document strings to be reranked.
+   * @param options Optional parameters for reranking.
+   * @returns A promise that resolves to an array of RerankedDocument objects, sorted by relevance.
+   */
+  rerank(query: string, documents: string[], options?: RerankerOptions): Promise<RerankedDocument[]>;
+
+  /**
+   * Optional: Initialize Provider (e.g., load models, check API keys)
+   * If not needed, can be a no-op.
+   */
+  initialize?(): Promise<void>;
+
+  /**
+   * Optional: Refresh configuration (e.g., if settings can change)
+   * If not needed, can be a no-op.
+   */
+  refresh?(): Promise<void>;
+}

--- a/src/providers/reranker/jina/jina.reranker.ts
+++ b/src/providers/reranker/jina/jina.reranker.ts
@@ -1,0 +1,243 @@
+// Get your Jina AI API key for free: https://jina.ai/?sui=apikey
+
+import {
+  RerankerProvider,
+  RerankerOptions,
+  RerankedDocument,
+} from "@src/providers/interfaces/reranker.interface.ts";
+import { z } from "npm:zod@3.23.8";
+
+// Zod Schema for Jina Reranker API Request
+const JinaRerankerRequestSchema = z.object({
+  model: z.string(),
+  query: z.string(),
+  documents: z.array(z.string()),
+  top_n: z.number().optional(),
+  return_documents: z.boolean().optional(),
+});
+
+// Zod Schema for a single result object in the Jina Reranker API Response
+const JinaRerankerResultSchema = z.object({
+  index: z.number(), // Original index of the document
+  relevance_score: z.number(),
+  document: z.object({ // Present if request had return_documents: true
+    text: z.string(),
+  }).optional(),
+});
+
+// Zod Schema for Jina Reranker API Response
+const JinaRerankerResponseSchema = z.object({
+  model: z.string(),
+  usage: z.object({
+    total_tokens: z.number().optional(), // Jina's usage object can vary
+    prompt_tokens: z.number().optional(),
+  }).optional(), // The entire usage object can be optional
+  results: z.array(JinaRerankerResultSchema),
+  message: z.string().optional(), // For potential error messages from API
+  detail: z.any().optional(), // For more detailed errors
+});
+
+
+export interface JinaRerankerProviderConfig {
+  model?: string; // Default: "jina-reranker-v2-base-multilingual"
+}
+
+export class JinaRerankerProvider implements RerankerProvider {
+  private apiKey: string;
+  private defaultModel: string;
+  private jinaApiUrl = "https://api.jina.ai/v1/rerank";
+
+  constructor(config?: JinaRerankerProviderConfig) {
+    const apiKey = Deno.env.get("JINA_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "JINA_API_KEY environment variable is not set. " +
+        "Get your Jina AI API key for free: https://jina.ai/?sui=apikey",
+      );
+    }
+    this.apiKey = apiKey;
+    // Recommended default by Jina for general purpose multilingual reranking.
+    this.defaultModel = config?.model || "jina-reranker-v2-base-multilingual";
+  }
+
+  async initialize(): Promise<void> {
+    // No specific initialization needed if API key is set
+    return Promise.resolve();
+  }
+
+  async refresh(): Promise<void> {
+    // No specific refresh logic needed unless config can change dynamically
+    return Promise.resolve();
+  }
+
+  async rerank(
+    query: string,
+    documents: string[],
+    options?: RerankerOptions,
+  ): Promise<RerankedDocument[]> {
+    const model = options?.model || this.defaultModel;
+    // `return_documents: false` is default by Jina.
+    // If true, Jina sends back document text. If false, we map it ourselves from input.
+    // For our RerankedDocument interface, we always need the document text.
+    // It's more efficient to set return_documents: false and map it from the input `documents` array.
+    const returnDocumentsApiOption = options?.returnDocuments ?? false;
+
+    const requestBody = JinaRerankerRequestSchema.parse({
+      model: model,
+      query: query,
+      documents: documents,
+      top_n: options?.topN, // Jina API handles undefined as "return all"
+      return_documents: returnDocumentsApiOption,
+    });
+
+    console.info(`[JinaRerankerProvider] Reranking ${documents.length} documents for query "${query.substring(0,50)}..." with model: ${model}`);
+
+    try {
+      const response = await fetch(this.jinaApiUrl, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          "Accept": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        let errorMessage = `Jina Reranker API request failed with status ${response.status}`;
+        try {
+            const errJson = JSON.parse(errorBody);
+            // Jina errors might be in `detail` or `message`
+            if (errJson.detail && typeof errJson.detail === 'string') {
+                 errorMessage = `Jina Reranker API Error: ${errJson.detail} (Status: ${response.status})`;
+            } else if (errJson.detail && errJson.detail.msg) { // FastAPI validation errors
+                 errorMessage = `Jina Reranker API Error: ${errJson.detail.msg} (Status: ${response.status})`;
+            } else if (errJson.message) {
+                 errorMessage = `Jina Reranker API Error: ${errJson.message} (Status: ${response.status})`;
+            } else {
+                 errorMessage += `: ${errorBody}`;
+            }
+        } catch (e) { 
+            errorMessage += `: ${errorBody}`;
+        }
+        console.error(`[JinaRerankerProvider] ${errorMessage}`);
+        throw new Error(errorMessage);
+      }
+
+      const result = await response.json();
+      const parsedResult = JinaRerankerResponseSchema.safeParse(result);
+
+      if (!parsedResult.success) {
+        console.error(
+          `[JinaRerankerProvider] Invalid API response structure: ${parsedResult.error.toString()}`,
+          result
+        );
+        throw new Error(
+          `Jina Reranker API returned an invalid response structure. ${parsedResult.error.toString()}`,
+        );
+      }
+      
+      const apiData = parsedResult.data;
+
+      if (!apiData.results) {
+        console.warn("[JinaRerankerProvider] API returned no results.", apiData);
+        return [];
+      }
+
+      // Map Jina's response to RerankedDocument[]
+      // The results from Jina are already sorted by relevance_score descending.
+      const rerankedDocs: RerankedDocument[] = apiData.results.map((res) => {
+        // Ensure the document text is correctly assigned
+        let documentText = "";
+        if (returnDocumentsApiOption && res.document?.text) {
+          documentText = res.document.text;
+        } else if (documents[res.index] !== undefined) {
+          // If Jina didn't return the document text, use the original document
+          // from the input array based on the index Jina provides.
+          documentText = documents[res.index];
+        } else {
+            // This case should ideally not happen if API and input are valid.
+            console.warn(`[JinaRerankerProvider] Document text not found for index ${res.index}. This might indicate an issue.`);
+        }
+
+        return {
+          document: documentText,
+          index: res.index,
+          relevanceScore: res.relevance_score,
+        };
+      });
+
+      return rerankedDocs;
+
+    } catch (error) {
+      console.error(`[JinaRerankerProvider] Error reranking documents for query "${query.substring(0,50)}...":`, error);
+      if (error instanceof Error) {
+        throw new Error(`Failed to rerank documents using Jina: ${error.message}`);
+      }
+      throw new Error(`Failed to rerank documents using Jina: Unknown error`);
+    }
+  }
+}
+
+// Example of how to use the provider (optional, for testing or demonstration)
+/*
+async function main() {
+  if (!Deno.env.get("JINA_API_KEY")) {
+    console.error("Please set the JINA_API_KEY environment variable.");
+    console.log("Get your Jina AI API key for free: https://jina.ai/?sui=apikey");
+    return;
+  }
+
+  // Instantiate with default model ("jina-reranker-v2-base-multilingual")
+  const rerankerProvider = new JinaRerankerProvider();
+  
+  // Or with a specific model
+  // const rerankerProviderWithConfig = new JinaRerankerProvider({ model: "jina-reranker-v1-base-en" });
+
+  const query = "What is the capital of France?";
+  const documentsToRerank = [
+    "Paris is known for the Eiffel Tower.", // Expected high score
+    "The capital of Germany is Berlin.",
+    "France is a country in Western Europe.",
+    "The Louvre Museum is located in Paris, France." // Expected high score
+  ];
+
+  try {
+    console.log(`Attempting to rerank ${documentsToRerank.length} documents for query: "${query}"`);
+    
+    // Example 1: Default options (all documents returned, sorted)
+    let rerankedResults = await rerankerProvider.rerank(query, documentsToRerank);
+    console.log("\n--- Reranked Results (Default Options) ---");
+    rerankedResults.forEach(result => {
+      console.log(
+        `Score: ${result.relevanceScore.toFixed(4)}, Index: ${result.index}, Doc: "${result.document}"`
+      );
+    });
+
+    // Example 2: With topN and a different model (if you have one configured or it's a valid Jina model)
+    const customOptions: RerankerOptions = {
+        topN: 2,
+        // model: "jina-reranker-v1-turbo-en" // Example of a different Jina reranker model
+        // returnDocuments: true // To test Jina returning document text
+    };
+    console.log(`\nAttempting to rerank with topN: ${customOptions.topN}`);
+    // Note: To use a different model, ensure it's compatible with your Jina API key and plan
+    rerankedResults = await rerankerProvider.rerank(query, documentsToRerank, customOptions);
+    console.log(`\n--- Reranked Results (topN: ${customOptions.topN}) ---`);
+    rerankedResults.forEach(result => {
+      console.log(
+        `Score: ${result.relevanceScore.toFixed(4)}, Index: ${result.index}, Doc: "${result.document}"`
+      );
+    });
+
+  } catch (error) {
+    console.error("\nError during Jina Reranker example:", error.message);
+  }
+}
+
+// To run this example:
+// 1. Ensure JINA_API_KEY is set in your environment.
+// 2. Uncomment the following line and run the file with Deno: `deno run -A src/providers/reranker/jina/jina.reranker.ts`
+// main();
+*/

--- a/src/providers/reranker/jina/tests/jina.reranker.test.ts
+++ b/src/providers/reranker/jina/tests/jina.reranker.test.ts
@@ -1,0 +1,259 @@
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+} from "@std/assert/mod.ts";
+import { JinaRerankerProvider } from "../jina.reranker.ts";
+import { RerankedDocument, RerankerOptions } from "@src/providers/interfaces/reranker.interface.ts";
+
+// Store the original fetch function
+const originalFetch = globalThis.fetch;
+let mockFetch: ((input: URL | Request | string, init?: RequestInit) => Promise<Response>) | null = null;
+
+// Helper to mock globalThis.fetch
+function MOCK_FETCH(mock: (input: URL | Request | string, init?: RequestInit) => Promise<Response>) {
+  globalThis.fetch = mock;
+  mockFetch = mock;
+}
+
+// Helper to restore original fetch
+function RESTORE_FETCH() {
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+  mockFetch = null;
+}
+
+const MOCK_JINA_API_KEY = "test-jina-api-key-reranker";
+const DEFAULT_MODEL = "jina-reranker-v2-base-multilingual";
+const CUSTOM_MODEL = "jina-reranker-v1-base-en";
+
+const TEST_QUERY = "What is the capital of France?";
+const TEST_DOCUMENTS = [
+  "Paris is known for the Eiffel Tower.", // Expected high score, index 0
+  "The capital of Germany is Berlin.",    // index 1
+  "France is a country in Western Europe.",// index 2
+  "The Louvre Museum is located in Paris, France.", // Expected high score, index 3
+];
+
+
+Deno.test({
+  name: "[JinaRerankerProvider] Successful rerank (default model, return_documents: false)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    
+    const mockResponseData = {
+      model: DEFAULT_MODEL,
+      usage: { total_tokens: 100 },
+      results: [
+        { index: 0, relevance_score: 0.95 }, // Original index 0
+        { index: 3, relevance_score: 0.92 }, // Original index 3
+        { index: 2, relevance_score: 0.50 }, // Original index 2
+        { index: 1, relevance_score: 0.10 }, // Original index 1
+      ],
+    };
+
+    MOCK_FETCH(async (input: URL | Request | string, init?: RequestInit) => {
+      assertEquals(input, "https://api.jina.ai/v1/rerank");
+      assertEquals(init?.method, "POST");
+      assertEquals(init?.headers?.get("Authorization"), `Bearer ${MOCK_JINA_API_KEY}`);
+      const body = await init?.json();
+      assertEquals(body?.model, DEFAULT_MODEL);
+      assertEquals(body?.query, TEST_QUERY);
+      assertEquals(body?.documents, TEST_DOCUMENTS);
+      assertEquals(body?.return_documents, false); // Default behavior tested here
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const provider = new JinaRerankerProvider(); // Uses default model
+    const results: RerankedDocument[] = await provider.rerank(TEST_QUERY, TEST_DOCUMENTS);
+
+    assertEquals(results.length, 4);
+    // Check if results are sorted by score (Jina API does this, provider should preserve)
+    assertEquals(results[0].relevanceScore, 0.95);
+    assertEquals(results[1].relevanceScore, 0.92);
+    
+    // Check mapping from original documents based on index
+    assertEquals(results[0].document, TEST_DOCUMENTS[0]); // index 0
+    assertEquals(results[0].index, 0);
+    assertEquals(results[1].document, TEST_DOCUMENTS[3]); // index 3
+    assertEquals(results[1].index, 3);
+    assertEquals(results[2].document, TEST_DOCUMENTS[2]); // index 2
+    assertEquals(results[2].index, 2);
+    assertEquals(results[3].document, TEST_DOCUMENTS[1]); // index 1
+    assertEquals(results[3].index, 1);
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaRerankerProvider] Successful rerank with topN and return_documents: true",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const topN = 2;
+    const options: RerankerOptions = { topN, model: CUSTOM_MODEL, returnDocuments: true };
+
+    const mockResponseData = {
+      model: CUSTOM_MODEL,
+      usage: { total_tokens: 100 },
+      results: [ // Jina would return only topN if top_n is sent, but we test our mapping
+        { index: 0, relevance_score: 0.95, document: { text: TEST_DOCUMENTS[0] } },
+        { index: 3, relevance_score: 0.92, document: { text: TEST_DOCUMENTS[3] } },
+      ],
+    };
+
+    MOCK_FETCH(async (_input, init) => {
+      const body = await init?.json();
+      assertEquals(body?.model, CUSTOM_MODEL);
+      assertEquals(body?.top_n, topN);
+      assertEquals(body?.return_documents, true);
+      return Promise.resolve(new Response(JSON.stringify(mockResponseData), { status: 200 }));
+    });
+
+    const provider = new JinaRerankerProvider({ model: CUSTOM_MODEL }); // Can also set model in constructor
+    const results = await provider.rerank(TEST_QUERY, TEST_DOCUMENTS, options);
+
+    assertEquals(results.length, topN);
+    assertEquals(results[0].document, TEST_DOCUMENTS[0]);
+    assertEquals(results[0].relevanceScore, 0.95);
+    assertEquals(results[1].document, TEST_DOCUMENTS[3]);
+    assertEquals(results[1].relevanceScore, 0.92);
+
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  }
+});
+
+Deno.test({
+  name: "[JinaRerankerProvider] API Error (500)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(new Response("Internal Server Error", { status: 500 }));
+    });
+
+    const provider = new JinaRerankerProvider();
+    await assertRejects(
+      () => provider.rerank(TEST_QUERY, TEST_DOCUMENTS),
+      Error,
+      "Jina Reranker API request failed with status 500: Internal Server Error",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaRerankerProvider] API Error with Jina specific JSON detail (e.g. FastAPI error)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const errorJson = { detail: [{ loc: ["body", "query"], msg: "field required", type: "value_error.missing" }]};
+    // This is a common FastAPI validation error structure. The message parsing should handle it.
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(new Response(JSON.stringify(errorJson), { status: 422, headers: { "Content-Type": "application/json" } }));
+    });
+
+    const provider = new JinaRerankerProvider();
+    await assertRejects(
+      () => provider.rerank(TEST_QUERY, TEST_DOCUMENTS),
+      Error,
+      "Jina Reranker API Error: field required (Status: 422)", // Provider extracts the msg
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+
+Deno.test({
+  name: "[JinaRerankerProvider] Response Validation Error (Malformed JSON)",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const malformedResponse = {
+      // Missing 'results' or 'model'
+      unexpected_field: "unexpected_value",
+    };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(malformedResponse), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const provider = new JinaRerankerProvider();
+    await assertRejects(
+      () => provider.rerank(TEST_QUERY, TEST_DOCUMENTS),
+      Error, 
+      "Jina Reranker API returned an invalid response structure.",
+    );
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+Deno.test({
+  name: "[JinaRerankerProvider] API returns no results in array",
+  async fn() {
+    Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+    const mockResponseData = {
+      model: DEFAULT_MODEL,
+      results: [], // Empty results array
+    };
+
+    MOCK_FETCH(async (_input, _init) => {
+      return Promise.resolve(
+        new Response(JSON.stringify(mockResponseData), { status: 200, headers: { "Content-Type": "application/json" }})
+      );
+    });
+
+    const provider = new JinaRerankerProvider();
+    const results = await provider.rerank(TEST_QUERY, TEST_DOCUMENTS);
+    assertEquals(results.length, 0); // Expect empty array, not an error
+    
+    RESTORE_FETCH();
+    Deno.env.delete("JINA_API_KEY");
+  },
+});
+
+
+Deno.test({
+  name: "[JinaRerankerProvider] Constructor API Key Check (Missing)",
+  fn() {
+    Deno.env.delete("JINA_API_KEY");
+    assertRejects(
+      () => { new JinaRerankerProvider(); },
+      Error,
+      "JINA_API_KEY environment variable is not set.",
+    );
+  },
+});
+
+Deno.test({
+    name: "[JinaRerankerProvider] Constructor API Key Check (Present)",
+    fn() {
+      Deno.env.set("JINA_API_KEY", MOCK_JINA_API_KEY);
+      try {
+        new JinaRerankerProvider();
+      } catch (e) {
+        assert(false, `Should not throw when API key is present: ${e.message}`);
+      } finally {
+        Deno.env.delete("JINA_API_KEY");
+      }
+    },
+  });
+
+// Safeguard teardown
+globalThis.addEventListener("unload", () => {
+    if (mockFetch) {
+        RESTORE_FETCH();
+    }
+});


### PR DESCRIPTION
I removed the detailed "Jina AI API Key" section from README.md to reduce redundancy. The main README now contains only brief mentions of Jina AI in the "Tech Stack" and "Environment Variables Configuration" sections, with direct links to the comprehensive `docs/jina_integration_guide.md` for detailed information.

This change further simplifies the main README and ensures that you are directed to the dedicated Jina integration guide for specifics on setup and component usage. Information about the JINA_API_KEY is also present in `.env.example`.