### PR TITLE
Add LaTeX citation key generator and tests

### DIFF
--- a/src/test/citation-key.test.ts
+++ b/src/test/citation-key.test.ts
@@ -1,0 +1,27 @@
+import { assertEquals } from "https://deno.land/std@0.217.0/assert/mod.ts";
+import { buildLatexCitationKey } from "@src/utils/common.ts";
+
+Deno.test("buildLatexCitationKey: 兼容 Google Scholar 作者格式（逗号分隔）", () => {
+  const key = buildLatexCitationKey(
+    "Li S, Yang B, Hu J",
+    "2011",
+    "Performance comparison of different multi-resolution transforms for image fusion",
+  );
+
+  assertEquals(key, "li2011performance");
+});
+
+Deno.test("buildLatexCitationKey: 兼容 and 连接作者", () => {
+  const key = buildLatexCitationKey(
+    "Li S and Yang B and Hu J",
+    "2011",
+    "Performance comparison of different multi-resolution transforms for image fusion",
+  );
+
+  assertEquals(key, "li2011performance");
+});
+
+Deno.test("buildLatexCitationKey: 跳过停用词", () => {
+  const key = buildLatexCitationKey("Smith J", 2024, "The analysis of data systems");
+  assertEquals(key, "smith2024analysis");
+});

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -34,3 +34,61 @@ export function formatDate(dateString: string): string {
 
   return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`;
 }
+
+function normalizeToken(input: string): string {
+  return input
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+}
+
+function extractPrimaryAuthorSurname(author: string): string {
+  const firstAuthor = author
+    .split(/\band\b|;|\s+et\s+al\.?/i)
+    .map((part) => part.trim())
+    .filter(Boolean)[0] ?? "ref";
+
+  // 保留逗号前的主要姓名片段，例如 "Li S, Yang B, Hu J" -> "Li S"
+  const primaryName = firstAuthor.split(",")[0]?.trim() || firstAuthor;
+  const nameParts = primaryName.split(/\s+/).filter(Boolean);
+
+  if (nameParts.length === 0) {
+    return "ref";
+  }
+
+  if (nameParts.length === 1) {
+    return normalizeToken(nameParts[0]);
+  }
+
+  // Google Scholar 常见格式: "Li S" / "Smith J"（姓在前，名缩写在后）
+  if (/^[A-Z]([.-]?[A-Z])*$/i.test(nameParts[nameParts.length - 1])) {
+    return normalizeToken(nameParts[0]);
+  }
+
+  // 常见格式: "John Smith"（姓在后）
+  return normalizeToken(nameParts[nameParts.length - 1]);
+}
+
+/**
+ * 生成更稳定的 LaTeX/BibTeX 引用 key，格式：{firstAuthorLastName}{year}{firstMeaningfulWord}
+ * 例如：Li + 2011 + Performance => li2011performance
+ */
+export function buildLatexCitationKey(
+  author: string,
+  year: string | number,
+  title: string,
+): string {
+  const yearText = String(year).match(/\d{4}/)?.[0] ?? String(year);
+  const authorToken = extractPrimaryAuthorSurname(author);
+
+  const stopWords = new Set(["a", "an", "the", "of", "on", "for", "and", "in", "to"]);
+  const titleWords = title
+    .split(/\s+/)
+    .map((word) => normalizeToken(word))
+    .filter(Boolean);
+  const firstMeaningfulWord =
+    titleWords.find((word) => !stopWords.has(word)) ?? titleWords[0] ?? "paper";
+
+  return `${authorToken || "ref"}${yearText}${firstMeaningfulWord}`;
+}


### PR DESCRIPTION
### Motivation
- Provide a stable way to generate LaTeX/BibTeX citation keys from author, year, and title to improve bibliography consistency.
- Handle common author formats (Google Scholar comma-separated, `and`-joined, `et al.`) and normalize international characters.

### Description
- Add `buildLatexCitationKey` to `src/utils/common.ts` which produces keys of the form `{authorSurname}{year}{firstMeaningfulWord}` and extracts a four-digit year when available.
- Implement helper functions `normalizeToken` and `extractPrimaryAuthorSurname` to normalize diacritics, strip non-alphanumerics, and detect surname in multiple author name formats.
- Add stop-word filtering for titles to skip words like `a`, `an`, `the`, `of`, etc., when selecting the first meaningful title token.
- Add unit tests in `src/test/citation-key.test.ts` covering comma-separated Google Scholar author strings, `and`-joined authors, and skipping stop words in titles.

### Testing
- Ran `deno test src/test/citation-key.test.ts` and the added tests for `buildLatexCitationKey` passed.
- No other automated test failures were observed when running the repository's test suite with the new test included.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abf8dd05608323834786bdb5763015)