### PR TITLE
Add Xquik fallback for Twitter scraping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,8 @@ JINA_API_KEY="your_jina_api_key"
 
 # Twitter API配置 https://twitterapi.io/
 X_API_BEARER_TOKEN="your_api_key"
+# 可选：Xquik 备用抓取源 https://xquik.com/
+XQUIK_API_KEY="your_xquik_api_key"
 
 # ===================================
 # 其他通用配置

--- a/ENV_CONFIGURATION.md
+++ b/ENV_CONFIGURATION.md
@@ -112,6 +112,8 @@ FIRE_CRAWL_API_KEY="your_api_key"  # FireCrawl API密钥
 
 # Twitter API配置 https://twitterapi.io/
 X_API_BEARER_TOKEN="your_api_key"  # Twitter API Bearer Token
+# 可选：Xquik 备用抓取源 https://xquik.com/
+XQUIK_API_KEY="your_xquik_api_key"  # Xquik API Key
 ```
 
 ### 通知服务配置

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ npm run docs:build
 - 🤖 多源数据采集
 
   - Twitter/X 内容抓取
+  - Xquik 可作为 Twitter/X 抓取备用来源
   - 网站内容抓取 (基于 FireCrawl)
   - 支持自定义数据源配置
   - Advanced scraping and search via Jina AI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,7 @@ AI_SUMMARIZER_LLM_PROVIDER="QWEN:qwen-max"
 - `FIRE_CRAWL_API_KEY`: FireCrawl 抓取
 - `JINA_API_KEY`: Jina Reader / DeepSearch / Embedding / Rerank
 - `X_API_BEARER_TOKEN`: Twitter/X 抓取
+- `XQUIK_API_KEY`: 可选，Twitter/X 抓取备用来源
 
 ### 3. 微信发布
 

--- a/src/modules/scrapers/tests/twitter.xquik.scraper.test.ts
+++ b/src/modules/scrapers/tests/twitter.xquik.scraper.test.ts
@@ -1,0 +1,172 @@
+import { assertEquals } from "@std/assert";
+import { TwitterScraper } from "@src/modules/scrapers/twitter.scraper.ts";
+import {
+  ConfigManager,
+  ConfigurationError,
+} from "@src/utils/config/config-manager.ts";
+
+type FetchCall = {
+  url: string;
+  init?: RequestInit;
+};
+
+const originalFetch = globalThis.fetch;
+
+function mockConfig(
+  getValue: (key: string) => Promise<string>,
+): () => void {
+  const configManager = ConfigManager.getInstance();
+  const originalGet = configManager.get;
+  configManager.get =
+    (<T>(key: string) => getValue(key) as Promise<T>) as ConfigManager["get"];
+
+  return () => {
+    configManager.get = originalGet;
+  };
+}
+
+function getHeaderValue(init: RequestInit | undefined, key: string): string {
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.[key] ?? "";
+}
+
+Deno.test("TwitterScraper - uses Xquik when only XQUIK_API_KEY is configured", async () => {
+  const restoreConfig = mockConfig((key) => {
+    if (key === "XQUIK_API_KEY") {
+      return Promise.resolve("xquik_test_key");
+    }
+    return Promise.reject(
+      new ConfigurationError(`Configuration key "${key}" not found`),
+    );
+  });
+  const fetchCalls: FetchCall[] = [];
+
+  globalThis.fetch = (input: URL | Request | string, init?: RequestInit) => {
+    fetchCalls.push({
+      url: input.toString(),
+      init,
+    });
+
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          tweets: [
+            {
+              id: "123",
+              text: "Xquik fallback works",
+              createdAt: "2026-05-16T12:00:00Z",
+              url: "https://x.com/xquikcom/status/123",
+              media: [
+                {
+                  mediaUrl: "https://pbs.twimg.com/media/example.jpg",
+                  type: "photo",
+                },
+              ],
+            },
+          ],
+          has_next_page: false,
+          next_cursor: "",
+        }),
+        { status: 200 },
+      ),
+    );
+  };
+
+  try {
+    const scraper = new TwitterScraper();
+    const result = await scraper.scrape("https://x.com/xquikcom", {
+      limit: 1,
+    });
+
+    assertEquals(fetchCalls.length, 1);
+    const requestUrl = new URL(fetchCalls[0].url);
+    assertEquals(requestUrl.origin, "https://xquik.com");
+    assertEquals(requestUrl.pathname, "/api/v1/x/tweets/search");
+    assertEquals(
+      requestUrl.searchParams.get("q"),
+      "from:xquikcom -filter:replies within_time:24h",
+    );
+    assertEquals(requestUrl.searchParams.get("queryType"), "Top");
+    assertEquals(requestUrl.searchParams.get("limit"), "1");
+    assertEquals(
+      getHeaderValue(fetchCalls[0].init, "x-api-key"),
+      "xquik_test_key",
+    );
+    assertEquals(
+      getHeaderValue(fetchCalls[0].init, "xquik-api-contract"),
+      "2026-04-29",
+    );
+    assertEquals(result.length, 1);
+    assertEquals(result[0].id, "123");
+    assertEquals(
+      result[0].media?.[0].url,
+      "https://pbs.twimg.com/media/example.jpg",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreConfig();
+  }
+});
+
+Deno.test("TwitterScraper - falls back to Xquik after TwitterAPI.io fails", async () => {
+  const restoreConfig = mockConfig((key) => {
+    if (key === "X_API_BEARER_TOKEN") {
+      return Promise.resolve("twitterapi_test_key");
+    }
+    if (key === "XQUIK_API_KEY") {
+      return Promise.resolve("xquik_test_key");
+    }
+    return Promise.reject(
+      new ConfigurationError(`Configuration key "${key}" not found`),
+    );
+  });
+  const fetchCalls: FetchCall[] = [];
+
+  globalThis.fetch = (input: URL | Request | string, init?: RequestInit) => {
+    fetchCalls.push({
+      url: input.toString(),
+      init,
+    });
+
+    if (input.toString().startsWith("https://api.twitterapi.io/")) {
+      return Promise.resolve(new Response("error", { status: 500 }));
+    }
+
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          tweets: [
+            {
+              id: "456",
+              text: "Fallback result",
+              createdAt: "2026-05-16T12:00:00Z",
+              url: "https://x.com/xquikcom/status/456",
+            },
+          ],
+          has_next_page: false,
+          next_cursor: "",
+        }),
+        { status: 200 },
+      ),
+    );
+  };
+
+  try {
+    const scraper = new TwitterScraper();
+    const result = await scraper.scrape("https://x.com/xquikcom", {
+      limit: 1,
+    });
+
+    assertEquals(fetchCalls.length, 2);
+    assertEquals(
+      fetchCalls[0].url.startsWith("https://api.twitterapi.io/"),
+      true,
+    );
+    assertEquals(fetchCalls[1].url.startsWith("https://xquik.com/"), true);
+    assertEquals(result.length, 1);
+    assertEquals(result[0].content, "Fallback result");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreConfig();
+  }
+});

--- a/src/modules/scrapers/twitter.scraper.ts
+++ b/src/modules/scrapers/twitter.scraper.ts
@@ -4,23 +4,73 @@ import {
   ScrapedContent,
   ScraperOptions,
 } from "@src/modules/interfaces/scraper.interface.ts";
-import { ConfigManager } from "@src/utils/config/config-manager.ts";
+import {
+  ConfigManager,
+  ConfigurationError,
+} from "@src/utils/config/config-manager.ts";
 import { formatDate } from "@src/utils/common.ts";
 import { Logger } from "@zilla/logger";
 
 const logger = new Logger("twitter-scraper");
+const DEFAULT_TWEET_LIMIT = 20;
+const XQUIK_API_CONTRACT = "2026-04-29";
+
+interface TweetMediaSize {
+  w?: number;
+  h?: number;
+}
+
+interface TweetMedia {
+  media_url_https?: string;
+  mediaUrl?: string;
+  url?: string;
+  type?: string;
+  sizes?: {
+    large?: TweetMediaSize;
+  };
+}
+
+interface TweetRecord {
+  id?: string;
+  text?: string;
+  url?: string;
+  createdAt?: string;
+  extendedEntities?: {
+    media?: TweetMedia[];
+  };
+  media?: TweetMedia[];
+  quoted_tweet?: TweetRecord;
+}
+
+interface TweetSearchResponse {
+  tweets?: TweetRecord[];
+}
 
 export class TwitterScraper implements ContentScraper {
   private xApiBearerToken: string | undefined;
+  private xquikApiKey: string | undefined;
 
   constructor() {
   }
 
   async refresh(): Promise<void> {
     const startTime = Date.now();
-    this.xApiBearerToken = await ConfigManager.getInstance().get(
+    const configManager = ConfigManager.getInstance();
+    this.xApiBearerToken = await this.getOptionalConfig(
+      configManager,
       "X_API_BEARER_TOKEN",
     );
+    this.xquikApiKey = await this.getOptionalConfig(
+      configManager,
+      "XQUIK_API_KEY",
+    );
+
+    if (!this.xApiBearerToken && !this.xquikApiKey) {
+      throw new ConfigurationError(
+        "Configure X_API_BEARER_TOKEN or XQUIK_API_KEY for Twitter scraping",
+      );
+    }
+
     logger.debug(
       `TwitterScraper 初始化完成, 耗时: ${Date.now() - startTime}ms`,
     );
@@ -41,44 +91,28 @@ export class TwitterScraper implements ContentScraper {
 
     try {
       const query = `from:${username} -filter:replies within_time:24h`;
-      const apiUrl =
-        `https://api.twitterapi.io/twitter/tweet/advanced_search?query=${
-          encodeURIComponent(
-            query,
-          )
-        }&queryType=Top`;
-
-      const response = await fetch(apiUrl, {
-        headers: {
-          "X-API-Key": `${this.xApiBearerToken}`,
-        },
-      });
-
-      if (!response.ok) {
-        const errorMsg = `Failed to fetch tweets: ${response.statusText}`;
-        throw new Error(errorMsg);
-      }
-
-      const tweets = await response.json();
-      const scrapedContent: ScrapedContent[] = tweets.tweets
-        .slice(0, 20)
-        .map((tweet: any) => {
+      const limit = options?.limit ?? DEFAULT_TWEET_LIMIT;
+      const tweets = await this.fetchTweets(query, limit);
+      const scrapedContent: ScrapedContent[] = tweets
+        .slice(0, limit)
+        .map((tweet) => {
           const quotedContent = this.getQuotedContent(tweet.quoted_tweet);
-          let media = this.getMediaList(tweet.extendedEntities);
+          let media = this.getMediaList(tweet);
           // 合并tweet和quotedContent 如果quotedContent存在，则将quotedContent的内容添加到tweet的内容中
+          const tweetText = tweet.text ?? "";
           const content = quotedContent
-            ? `${tweet.text}\n\n 【QuotedContent:${quotedContent.content}】`
-            : tweet.text;
+            ? `${tweetText}\n\n 【QuotedContent:${quotedContent.content}】`
+            : tweetText;
           // 合并media和quotedContent的media
           if (quotedContent?.media) {
             media = [...media, ...quotedContent.media];
           }
           return {
-            id: tweet.id,
-            title: tweet.text.split("\n")[0],
+            id: tweet.id ?? "",
+            title: tweetText.split("\n")[0],
             content: content,
-            url: tweet.url,
-            publishDate: formatDate(tweet.createdAt),
+            url: tweet.url ?? this.getTweetUrl(username, tweet.id),
+            publishDate: tweet.createdAt ? formatDate(tweet.createdAt) : "",
             media: media,
             metadata: {
               platform: "twitter",
@@ -105,37 +139,148 @@ export class TwitterScraper implements ContentScraper {
     }
   }
 
-  private getMediaList(extendedEntities: any): Media[] {
+  private async getOptionalConfig(
+    configManager: ConfigManager,
+    key: string,
+  ): Promise<string | undefined> {
+    try {
+      const value = await configManager.get<string>(key);
+      return typeof value === "string" ? value.trim() || undefined : undefined;
+    } catch (error) {
+      if (error instanceof ConfigurationError) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  private async fetchTweets(
+    query: string,
+    limit: number,
+  ): Promise<TweetRecord[]> {
+    if (this.xApiBearerToken) {
+      try {
+        return await this.fetchTwitterApiTweets(query);
+      } catch (error) {
+        if (!this.xquikApiKey) {
+          throw error;
+        }
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.warn(
+          "TwitterAPI.io request failed, falling back to Xquik:",
+          errorMsg,
+        );
+      }
+    }
+
+    if (this.xquikApiKey) {
+      return await this.fetchXquikTweets(query, limit);
+    }
+
+    throw new ConfigurationError(
+      "Configure X_API_BEARER_TOKEN or XQUIK_API_KEY for Twitter scraping",
+    );
+  }
+
+  private async fetchTwitterApiTweets(query: string): Promise<TweetRecord[]> {
+    const apiUrl =
+      `https://api.twitterapi.io/twitter/tweet/advanced_search?query=${
+        encodeURIComponent(
+          query,
+        )
+      }&queryType=Top`;
+
+    const response = await fetch(apiUrl, {
+      headers: {
+        "X-API-Key": `${this.xApiBearerToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorMsg = `Failed to fetch tweets: ${response.statusText}`;
+      throw new Error(errorMsg);
+    }
+
+    const tweets = await response.json() as TweetSearchResponse;
+    return tweets.tweets ?? [];
+  }
+
+  private async fetchXquikTweets(
+    query: string,
+    limit: number,
+  ): Promise<TweetRecord[]> {
+    const apiUrl = new URL("https://xquik.com/api/v1/x/tweets/search");
+    apiUrl.searchParams.set("q", query);
+    apiUrl.searchParams.set("queryType", "Top");
+    apiUrl.searchParams.set("limit", String(limit));
+
+    const response = await fetch(apiUrl, {
+      headers: {
+        "x-api-key": `${this.xquikApiKey}`,
+        "xquik-api-contract": XQUIK_API_CONTRACT,
+      },
+    });
+
+    if (!response.ok) {
+      const errorMsg =
+        `Failed to fetch tweets from Xquik: ${response.statusText}`;
+      throw new Error(errorMsg);
+    }
+
+    const tweets = await response.json() as TweetSearchResponse;
+    return tweets.tweets ?? [];
+  }
+
+  private getMediaList(tweet: TweetRecord): Media[] {
     const mediaList: Media[] = [];
-    if (extendedEntities && extendedEntities.media) {
-      extendedEntities.media.forEach((media: any) => {
-        mediaList.push({
-          url: media.media_url_https,
-          type: media.type,
-          size: {
-            width: media.sizes.large.w,
-            height: media.sizes.large.h,
-          },
-        });
+    const tweetMedia = [
+      ...(tweet.extendedEntities?.media ?? []),
+      ...(tweet.media ?? []),
+    ];
+
+    for (const media of tweetMedia) {
+      const mediaUrl = media.media_url_https ?? media.mediaUrl ?? media.url;
+      if (!mediaUrl) {
+        continue;
+      }
+
+      mediaList.push({
+        url: mediaUrl,
+        type: media.type ?? "photo",
+        size: {
+          width: media.sizes?.large?.w ?? 0,
+          height: media.sizes?.large?.h ?? 0,
+        },
       });
     }
+
     return mediaList;
   }
 
-  private getQuotedContent(quoted_tweet: any): ScrapedContent | null {
+  private getQuotedContent(quoted_tweet?: TweetRecord): ScrapedContent | null {
     if (quoted_tweet) {
+      const tweetText = quoted_tweet.text ?? "";
       return {
-        id: quoted_tweet.id,
-        title: quoted_tweet.text.split("\n")[0],
-        content: quoted_tweet.text,
-        url: quoted_tweet.url,
-        publishDate: formatDate(quoted_tweet.createdAt),
-        media: this.getMediaList(quoted_tweet.extendedEntities),
+        id: quoted_tweet.id ?? "",
+        title: tweetText.split("\n")[0],
+        content: tweetText,
+        url: quoted_tweet.url ?? "",
+        publishDate: quoted_tweet.createdAt
+          ? formatDate(quoted_tweet.createdAt)
+          : "",
+        media: this.getMediaList(quoted_tweet),
         metadata: {
           platform: "twitter",
         },
       };
     }
     return null;
+  }
+
+  private getTweetUrl(username: string, tweetId?: string): string {
+    if (!tweetId) {
+      return "";
+    }
+    return `https://x.com/${username}/status/${tweetId}`;
   }
 }


### PR DESCRIPTION
## Summary
- Adds optional `XQUIK_API_KEY` support for Twitter/X scraping.
- Keeps the existing TwitterAPI.io path first when `X_API_BEARER_TOKEN` is configured, then falls back to Xquik on request failure.
- Uses Xquik directly when only `XQUIK_API_KEY` is configured.
- Maps Xquik search responses into the existing `ScrapedContent` shape and documents the optional env var.

## Validation
- `npm exec --yes deno -- fmt --check src/modules/scrapers/twitter.scraper.ts src/modules/scrapers/tests/twitter.xquik.scraper.test.ts`
- `npm exec --yes deno -- lint src/modules/scrapers/twitter.scraper.ts src/modules/scrapers/tests/twitter.xquik.scraper.test.ts`
- `npm exec --yes deno -- test --no-lock -A src/modules/scrapers/tests/twitter.xquik.scraper.test.ts`
