### PR TITLE
docs: clarify custom RSS source setup for issue #26

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,6 +329,26 @@ features: {
 FireCrawl；query 源默认推断到 Jina Search。`gdelt`、`hackernews`、`arxiv` 不需要
 API Key，适合免费补充新闻、技术社区和论文线索。
 
+如果你要直接接入自定义 RSS / Atom / JSON Feed，最小配置可以写成：
+
+```ts
+fetchGroups: {
+  default: ["auto"],
+},
+features: {
+  article: {
+    dryRun: true,
+    sources: [
+      "https://your-feed.example.com/rss.xml",
+      "https://another-feed.example.com/feed",
+    ],
+  },
+},
+```
+
+建议先执行一次 `deno task article --dry-run`，确认 run 产物里已经包含这些 RSS
+条目，再叠加 prompt profile、通知和正式发布配置。
+
 运行：
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,6 +55,29 @@ fetchGroups: {
 },
 ```
 
+如果你想直接聚合自己维护的 RSS / Atom / JSON Feed，也可以把订阅地址直接放进
+`features.article.sources`：
+
+```ts
+features: {
+  article: {
+    renderer: {
+      promptProfile: "technology",
+    },
+    sources: [
+      "https://your-feed.example.com/rss.xml",
+      "https://another-feed.example.com/atom.xml",
+    ],
+  },
+},
+fetchGroups: {
+  default: ["auto"],
+},
+```
+
+先运行 `deno task article --dry-run`，确认当天产物里已经出现自定义 RSS 的文章，
+再继续接入正式发布链路。
+
 更多功能开关和必填项见 [配置说明](/configuration)。
 
 ## 4. 本地启动


### PR DESCRIPTION
## Summary

- add explicit custom RSS / Atom / JSON Feed examples to getting started
- add a minimal `features.article.sources` example to configuration docs
- document the recommended `deno task article --dry-run` verification flow

## Verification

- `deno fmt docs/getting-started.md docs/configuration.md`

Fixes #26